### PR TITLE
fix(ui): Correct 'Add Property' button state after point creation

### DIFF
--- a/point-finder.html
+++ b/point-finder.html
@@ -2165,7 +2165,7 @@
                 updatePointsOutput(); setStatus(`Point "${name}" added.`, 'success');
                 pointNameInput.value = ''; pointPronunciationInput.value = ''; poiTypeSelect.value = ''; pointDescriptionInput.value = ''; pointSummaryInput.value = ''; pointWikiLinkInput.value = '';
                 displayProperties(pointPropertiesContainer, {});
-                coordsDisplay.textContent = '[Y, X]'; lastClickedCoordsArray = null; addPointBtn.disabled = true;
+                coordsDisplay.textContent = '[Y, X]'; lastClickedCoordsArray = null; addPointBtn.disabled = true; addPointPropertyBtn.disabled = true;
             });
             editPointSelect.addEventListener('change', (e) => e.target.value ? loadPointForEditing(e.target.value) : cancelPointEditing());
             savePointChangesBtn.addEventListener('click', savePointChanges);


### PR DESCRIPTION
In the point-finder tool, the 'Add Property' button remained enabled after a new point was successfully created and the form was cleared. This was incorrect because there was no longer an active point object to which properties could be attached.

This commit fixes the issue by explicitly disabling the 'addPointPropertyBtn' after a point is added, ensuring the UI state accurately reflects the application's logic.