### PR TITLE
fix(point-finder): Export scaleKilometers correctly

### DIFF
--- a/point-finder.html
+++ b/point-finder.html
@@ -1894,8 +1894,7 @@
             const sortedLines = [...collectedLines].sort((a, b) => (a.name || a.id).localeCompare(b.name || b.id));
 
             mapToUpdate.scalePixels = parseInt(scalePixelsInput.value) || 3;
-            mapToUpdate.scaleUnits = parseFloat(scaleUnitsInput.value) || 1;
-            delete mapToUpdate.scaleKilometers; // Remove old key if it exists
+            mapToUpdate.scaleKilometers = parseFloat(scaleUnitsInput.value) || 1;
             mapToUpdate.blurb = mapBlurbInput.value || "";
 
             mapToUpdate.pointsOfInterest = sortedPoints.map(p => ({


### PR DESCRIPTION
The point-finder.html tool was incorrectly saving the map scale to `scaleUnits` and deleting the `scaleKilometers` property.

This change corrects the export logic to save the value to `scaleKilometers`, which is the key expected by the main application's measurement and scaling tools.