### PR TITLE
Standardize UI Icons with Lucide + Sidebar UX Clarifications

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -146,7 +146,8 @@ a:focus-visible,
 button:focus-visible,
 input:focus-visible,
 .map-item:focus-visible,
-.folder-header:focus-visible,
+.folder-toggle-btn:focus-visible,
+.folder-main-action:focus-visible,
 .search-result-item:focus-visible {
     outline: 2px solid var(--focus-ring);
     outline-offset: 2px;
@@ -180,43 +181,109 @@ body.dark-theme #sidebar h2 { border-bottom-color: var(--glass-border-dark); }
 .map-item:hover { background-color: var(--highlight-bg); }
 .map-item.active { background-color: var(--active-bg); font-weight: 600; }
 .folder-header {
-    padding: 10px 5px; cursor: pointer; font-weight: bold; display: flex;
-    align-items: center; transition: background-color 0.2s ease; background-color: transparent;
-    user-select: none; /* Prevent text selection on double click */
+    display: flex;
+    align-items: stretch;
+    gap: 2px;
+    background-color: transparent;
+    user-select: none;
     -webkit-user-select: none;
     -moz-user-select: none;
     -ms-user-select: none;
 }
-.folder-header:hover { background-color: var(--highlight-bg); }
-/* Style active folder header */
-.folder-header.active {
-        background-color: var(--active-bg);
-        font-weight: 600; /* Match map item active style */
+.folder-toggle-btn {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 30px;
+    min-width: 30px;
+    border: none;
+    border-radius: 4px;
+    background: transparent;
+    color: var(--text-secondary);
+    cursor: pointer;
+    margin: 2px 0 2px 3px;
 }
-.folder-toggle-icon { display: inline-block; width: 1.2em; text-align: center; margin-right: 5px; transition: transform 0.2s ease-in-out; }
-.folder.closed > .folder-header .folder-toggle-icon::before { content: '▸'; }
-.folder:not(.closed) > .folder-header .folder-toggle-icon::before { content: '▾'; }
+.folder-toggle-btn:hover {
+    background-color: var(--highlight-bg);
+    color: var(--text-primary);
+}
+.folder-toggle-btn:disabled {
+    opacity: 0;
+    pointer-events: none;
+}
+.sidebar-chevron-icon {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    transition: transform 0.2s ease-in-out;
+}
+.sidebar-chevron-icon .ui-icon {
+    width: 14px;
+    height: 14px;
+}
+.folder:not(.closed) > .folder-header .sidebar-chevron-icon {
+    transform: rotate(90deg);
+}
+.folder-main-action {
+    flex: 1;
+    min-width: 0;
+    display: inline-flex;
+    align-items: center;
+    gap: 8px;
+    padding: 10px 10px 10px 6px;
+    border: none;
+    border-radius: 4px;
+    background: transparent;
+    color: inherit;
+    cursor: pointer;
+    text-align: left;
+    font-size: 1.05rem;
+    font-weight: 600;
+}
+.folder-main-action:hover {
+    background-color: var(--highlight-bg);
+}
+.folder-main-action-label {
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
+.folder-load-icon {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    color: var(--text-secondary);
+    opacity: 0.8;
+}
+.folder-load-icon .ui-icon {
+    width: 14px;
+    height: 14px;
+}
+.folder-header.active .folder-main-action {
+    background-color: var(--active-bg);
+    font-weight: 600;
+}
 .nested-list { list-style: none; padding: 0; margin: 0 0 0 15px; max-height: 1000px; overflow: hidden; transition: max-height 0.3s ease-out; }
 .folder.closed > .nested-list { max-height: 0; }
 
 /* --- Coming Soon Sidebar Item Styling --- */
-.map-item.coming-soon, .folder-header.coming-soon {
+.map-item.coming-soon, .folder-header.coming-soon .folder-main-action {
     color: var(--text-secondary); /* Use secondary text color */
     font-style: italic;
     cursor: not-allowed; /* Indicate non-interactive */
     opacity: 0.7;
 }
 /* Optional: Prevent hover effect or use a different one */
-.map-item.coming-soon:hover, .folder-header.coming-soon:hover {
+.map-item.coming-soon:hover, .folder-header.coming-soon .folder-main-action:hover {
     background-color: transparent; /* No highlight on hover */
 }
 /* Ensure dark theme also looks disabled */
 body.dark-theme .map-item.coming-soon,
-body.dark-theme .folder-header.coming-soon {
+body.dark-theme .folder-header.coming-soon .folder-main-action {
         color: var(--text-secondary); /* Already uses variable */
 }
 body.dark-theme .map-item.coming-soon:hover,
-body.dark-theme .folder-header.coming-soon:hover {
+body.dark-theme .folder-header.coming-soon .folder-main-action:hover {
         background-color: transparent;
 }
 
@@ -531,12 +598,19 @@ body.dark-theme .leaflet-popup-content .popup-map-jump a:active {
     border: 1px solid var(--glass-border-light);
     color: var(--text-primary);
     border-radius: 4px;
-    padding: 5px 8px;
+    width: 34px;
+    height: 30px;
+    padding: 0;
     cursor: pointer;
-    font-size: 1.2rem;
-    line-height: 1;
+    line-height: 0;
     box-shadow: 0 1px 5px var(--shadow-color);
     transition: background-color 0.3s ease, border-color 0.3s ease;
+}
+#toggle-sidebar-btn .ui-icon {
+    position: absolute;
+    top: 50%;
+    left: 50%;
+    transform: translate(-50%, -50%);
 }
 #toggle-sidebar-btn:hover { background-color: rgba(255, 255, 255, 0.75); }
 body.dark-theme #toggle-sidebar-btn { background-color: var(--glass-bg-dark); border-color: var(--glass-border-dark); }
@@ -588,19 +662,26 @@ body.dark-theme .coordinate-control {
     background: none;
     border: none;
     cursor: pointer;
-    font-size: 1.1em;
-    padding: 0 0 0 5px;
+    padding: 0;
+    margin-left: 5px;
     transition: transform 0.2s ease-in-out, color 0.2s ease-in-out;
     position: relative; /* For positioning copied message */
     width: 20px; /* Give it a fixed width */
-    text-align: center;
+    height: 20px;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
 }
 .copy-coords-btn .copy-coords-icon {
-    display: inline-block;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
     transition: opacity 0.2s ease-in-out, transform 0.2s ease-in-out;
 }
 .copy-coords-btn .copy-coords-copied-msg {
-    display: inline-block;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
     position: absolute;
     left: 0;
     right: 0;
@@ -611,6 +692,11 @@ body.dark-theme .coordinate-control {
     font-weight: bold;
     color: var(--text-secondary);
     pointer-events: none; /* Don't intercept clicks */
+}
+.copy-coords-btn .copy-coords-icon .ui-icon,
+.copy-coords-btn .copy-coords-copied-msg .ui-icon {
+    width: 15px;
+    height: 15px;
 }
 .copy-coords-btn.copied .copy-coords-icon {
     opacity: 0;
@@ -690,12 +776,31 @@ body.dark-theme .onboarding-actions button {
     width: 32px; /* Match zoom control width */
     height: 30px; /* Match zoom control height */
     cursor: pointer;
-    font-size: 1.4rem; /* Adjust icon size */
-    line-height: 30px; /* Center icon vertically */
+    line-height: 0;
     text-align: center;
     box-shadow: 0 1px 5px var(--shadow-color);
     transition: all 0.2s ease; /* Smooth transition for all properties */
     display: none; /* Hide by default, shown via JS */
+    position: relative;
+}
+.ui-icon {
+    display: inline-block;
+    width: 18px;
+    height: 18px;
+    vertical-align: middle;
+    color: currentColor;
+}
+#toggle-sidebar-btn .ui-icon,
+.map-control-button .ui-icon,
+#sound-icon .ui-icon {
+    width: 20px;
+    height: 20px;
+}
+.map-control-button .ui-icon {
+    position: absolute;
+    top: 50%;
+    left: 50%;
+    transform: translate(-50%, -50%);
 }
 .map-control-button:hover {
     background-color: var(--highlight-bg); /* Use theme highlight */
@@ -839,18 +944,19 @@ body.dark-theme #poi-filter-container h3 {
     align-items: center;
     font-weight: bold; /* Make the group name stand out */
 }
-.filter-group-header .folder-toggle-icon { /* Re-use folder icon style */
-    display: inline-block;
-    width: 1.2em;
-    text-align: center;
+.filter-chevron-icon {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
     margin-right: 5px;
     transition: transform 0.2s ease-in-out;
 }
-.filter-group.closed > .filter-group-header .folder-toggle-icon::before {
-    content: '▸';
+.filter-chevron-icon .ui-icon {
+    width: 14px;
+    height: 14px;
 }
-.filter-group:not(.closed) > .filter-group-header .folder-toggle-icon::before {
-    content: '▾';
+.filter-group:not(.closed) > .filter-group-header .filter-chevron-icon {
+    transform: rotate(90deg);
 }
 .nested-filter-list {
     list-style: none;

--- a/index.html
+++ b/index.html
@@ -63,7 +63,7 @@
         </div>
         <div id="map-container">
             <button id="toggle-sidebar-btn" title="Collapse Sidebar" aria-label="Collapse Sidebar" aria-expanded="true">
-                <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="m15 18-6-6 6-6"/></svg>
+                <i class="ui-icon" data-lucide="chevron-left" aria-hidden="true"></i>
             </button>
             <div id="map"></div>
             <div id="star-field">
@@ -75,13 +75,13 @@
             <div id="map-blurb"></div>
             <div id="info-controls-container">
                 <button id="toggle-blurb-btn" class="map-control-button leaflet-control" title="Toggle Map Info" aria-label="Toggle Map Info" aria-expanded="false">
-                    <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="10"/><path d="M12 16v-4"/><path d="M12 8h.01"/></svg>
+                    <i class="ui-icon" data-lucide="info" aria-hidden="true"></i>
                 </button>
                 <button id="toggle-gm-panel-btn" class="map-control-button leaflet-control" title="Toggle GM View Panel" aria-label="Toggle GM View Panel" aria-pressed="false">
-                    <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M3 11a9 9 0 1 1 18 0"/><path d="M9 14v2a3 3 0 0 0 6 0v-2"/><path d="M8 11h8"/><path d="M12 3v2"/></svg>
+                    <i class="ui-icon" data-lucide="shield" aria-hidden="true"></i>
                 </button>
                 <button id="toggle-toolkit-panel-btn" class="map-control-button leaflet-control" title="Toggle Session Toolkit Panel" aria-label="Toggle Session Toolkit Panel" aria-pressed="false">
-                    <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M4 7h16v4H4z"/><path d="M4 11h16v9H4z"/><path d="M9 7v4"/><path d="M15 7v4"/></svg>
+                    <i class="ui-icon" data-lucide="briefcase" aria-hidden="true"></i>
                 </button>
             </div>
 
@@ -96,30 +96,30 @@
 
             <div id="map-controls-container">
                 <button id="custom-zoom-in" title="Zoom In" aria-label="Zoom In" class="map-control-button">
-                    <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><line x1="12" y1="5" x2="12" y2="19"></line><line x1="5" y1="12" x2="19" y2="12"></line></svg>
+                    <i class="ui-icon" data-lucide="plus" aria-hidden="true"></i>
                 </button>
                 <button id="custom-zoom-out" title="Zoom Out" aria-label="Zoom Out" class="map-control-button">
-                    <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><line x1="5" y1="12" x2="19" y2="12"></line></svg>
+                    <i class="ui-icon" data-lucide="minus" aria-hidden="true"></i>
                 </button>
                 <button id="toggle-markers-btn" title="Toggle Markers" aria-label="Hide Markers & Regions" class="map-control-button">
-                    <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M20 10c0 6-8 12-8 12s-8-6-8-12a8 8 0 0 1 16 0Z"/><circle cx="12" cy="10" r="3"/></svg>
+                    <i class="ui-icon" data-lucide="map-pin" aria-hidden="true"></i>
                 </button>
                 <button id="toggle-filters-btn" title="Toggle Filters" aria-label="Toggle Filters" aria-expanded="false" class="map-control-button">
-                    <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polygon points="12 2 2 7 12 12 22 7 12 2"/><polyline points="2 17 12 22 22 17"/><polyline points="2 12 12 17 22 12"/></svg>
+                    <i class="ui-icon" data-lucide="funnel" aria-hidden="true"></i>
                 </button>
                 <button id="measure-tool-btn" title="Measure Distance" aria-label="Measure Distance" aria-pressed="false" class="map-control-button">
-                    <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M21.8 13.598 10.402 2.201a3 3 0 0 0-4.243 0L2.2 6.157a3 3 0 0 0 0 4.243l11.398 11.398a3 3 0 0 0 4.243 0l3.957-3.957a3 3 0 0 0 0-4.243Z"/><path d="m6 10 2-2"/><path d="m10 14 2-2"/><path d="m14 18 2-2"/></svg>
+                    <i class="ui-icon" data-lucide="ruler" aria-hidden="true"></i>
                 </button>
                 <button id="toggle-sound-btn" title="Toggle Sound" aria-label="Unmute Sound" aria-pressed="false" class="map-control-button">
                     <span id="sound-icon">
-                        <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polygon points="11 5 6 9 2 9 2 15 6 15 11 19 11 5"/><line x1="23" x2="17" y1="9" y2="15"/><line x1="17" x2="23" y1="9" y2="15"/></svg>
+                        <i class="ui-icon" data-lucide="volume-x" aria-hidden="true"></i>
                     </span>
                 </button>
                 <button id="toggle-coords-btn" title="Toggle Coordinate Display" aria-label="Toggle Coordinate Display" class="map-control-button" style="display: none;">
-                    <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="10"/><line x1="2" x2="22" y1="12" y2="12"/><path d="M12 2a15.3 15.3 0 0 1 4 10 15.3 15.3 0 0 1-4 10 15.3 15.3 0 0 1 4-10z"/></svg>
+                    <i class="ui-icon" data-lucide="globe" aria-hidden="true"></i>
                 </button>
                 <button id="help-btn" title="Help & About" aria-label="Help and About" class="map-control-button">
-                    <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="10"/><path d="M9.09 9a3 3 0 0 1 5.83 1c0 2-3 3-3 3"/><path d="M12 17h.01"/></svg>
+                    <i class="ui-icon" data-lucide="circle-help" aria-hidden="true"></i>
                 </button>
             </div>
             <div id="onboarding-coachmark" role="status" aria-live="polite" hidden>
@@ -133,8 +133,12 @@
             <div id="coordinate-display" class="coordinate-control" style="display: none;">
                 <span>0.0° N, 0.0° W</span>
                 <button class="copy-coords-btn" title="Copy Coordinates" aria-label="Copy Coordinates">
-                    <span class="copy-coords-icon">📋</span>
-                    <span class="copy-coords-copied-msg">✔</span>
+                    <span class="copy-coords-icon" aria-hidden="true">
+                        <i class="ui-icon" data-lucide="copy"></i>
+                    </span>
+                    <span class="copy-coords-copied-msg" aria-hidden="true">
+                        <i class="ui-icon" data-lucide="check"></i>
+                    </span>
                 </button>
             </div>
 
@@ -235,6 +239,7 @@
     <script src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js"
         integrity="sha256-20nQCchB9co0qIjJZRGuk2/Z9VM+kNiyxNV1lvTlZBo="
         crossorigin=""></script>
+    <script src="https://unpkg.com/lucide@latest"></script>
 
     <script>
         (function loadVersionedLocalScripts() {

--- a/js/app.js
+++ b/js/app.js
@@ -35,6 +35,12 @@ let isAboutModalVisible = () => false;
 let loadingMapId = null;
 let lastTrackedSearchSignature = '';
 
+function refreshLucideIcons() {
+    if (window.lucide && typeof window.lucide.createIcons === 'function') {
+        window.lucide.createIcons();
+    }
+}
+
 // --- Measurement Tool State ---
 let isMeasuring = false; // Existing
 let measurementStartPoint = null; // Existing
@@ -51,6 +57,7 @@ const map = L.map('map', {
 
 // Register URL update listeners
 map.on('moveend zoomend', updateURLWithMapView);
+map.on('popupopen', refreshLucideIcons);
 
 // NOW Initialize measurementLayerGroup
 measurementLayerGroup = L.layerGroup().addTo(map);
@@ -204,8 +211,8 @@ function createPopupContent(data, type) {
         let shareButtonHtml = '';
         if (type) {
             // Using an SVG icon to match the site theme
-            const linkIconSvg = `<svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M10 13a5 5 0 0 0 7.54.54l3-3a5 5 0 0 0-7.07-7.07l-1.72 1.71"/><path d="M14 11a5 5 0 0 0-7.54-.54l-3 3a5 5 0 0 0 7.07 7.07l1.71-1.71"/></svg>`;
-            shareButtonHtml = ` <button class="share-btn" onclick="copyFeatureLink(this, '${type}', '${escapedName}')" title="Share this location">${linkIconSvg}</button>`;
+            const linkIcon = `<i class="ui-icon" data-lucide="link-2" aria-hidden="true"></i>`;
+            shareButtonHtml = ` <button class="share-btn" onclick="copyFeatureLink(this, '${type}', '${escapedName}')" title="Share this location">${linkIcon}</button>`;
         }
 
         if (data.wikiLink) {
@@ -221,7 +228,7 @@ function createPopupContent(data, type) {
     if (linkedMap) {
         const escapedLinkedMapId = escapeForSingleQuotedAttribute(linkedMap.id);
         const linkedMapName = sanitizeTextForHtml(linkedMap.name);
-        const mapJumpIcon = `<svg aria-hidden="true" viewBox="0 0 24 24" width="14" height="14" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M3 6h18v12H3z"/><path d="m9 10 3 2-3 2"/></svg>`;
+        const mapJumpIcon = `<i class="ui-icon" data-lucide="map" aria-hidden="true"></i>`;
         headerHtml += `<div class="popup-map-jump"><a href="#" onclick="return openLinkedMapFromPopup(event, '${escapedLinkedMapId}')" title="Open map: ${linkedMapName}">${mapJumpIcon}<span>Open ${linkedMapName} map</span></a></div>`;
     }
 
@@ -729,17 +736,18 @@ function setSidebarState(state, updateHash = true) {
         // Update SVG direction
         if (shouldBeCollapsed) {
             // Point Right (Expand)
-             toggleBtn.innerHTML = `<svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="m9 18 6-6-6-6"/></svg>`;
+             toggleBtn.innerHTML = `<i class="ui-icon" data-lucide="chevron-right" aria-hidden="true"></i>`;
              toggleBtn.title = 'Expand Sidebar';
              toggleBtn.setAttribute('aria-label', 'Expand Sidebar');
              toggleBtn.setAttribute('aria-expanded', 'false');
         } else {
             // Point Left (Collapse)
-            toggleBtn.innerHTML = `<svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="m15 18-6-6 6-6"/></svg>`;
+            toggleBtn.innerHTML = `<i class="ui-icon" data-lucide="chevron-left" aria-hidden="true"></i>`;
             toggleBtn.title = 'Collapse Sidebar';
             toggleBtn.setAttribute('aria-label', 'Collapse Sidebar');
             toggleBtn.setAttribute('aria-expanded', 'true');
         }
+        refreshLucideIcons();
 
         // Invalidate map size after CSS transition completes
         setTimeout(() => { map.invalidateSize({ animate: true }); }, transitionDuration);
@@ -1670,7 +1678,11 @@ function populateFilters(pointsOfInterest, mapId) {
 
                     const groupHeader = document.createElement('div');
                     groupHeader.className = 'filter-group-header';
-                    groupHeader.innerHTML = `<span class="folder-toggle-icon"></span>`;
+                    groupHeader.innerHTML = `
+                        <span class="filter-chevron-icon" aria-hidden="true">
+                            <i class="ui-icon" data-lucide="chevron-right"></i>
+                        </span>
+                    `;
 
                     const groupDiv = document.createElement('div');
                     groupDiv.className = 'filter-item';
@@ -1769,6 +1781,7 @@ function populateFilters(pointsOfInterest, mapId) {
     if (filtersPanelVisible) {
         positionFilterPanel();
     }
+    refreshLucideIcons();
 
     // Set initial state of the master toggle
     updateToggleAllCheckboxState();
@@ -2274,13 +2287,19 @@ function loadMap(mapId, updateHash = true) {
         let parent = activeMapItem.closest('.nested-list');
         while (parent) {
             const folderLi = parent.closest('.folder');
-            if (folderLi && folderLi.classList.contains('closed')) folderLi.classList.remove('closed');
+            if (folderLi && folderLi.classList.contains('closed')) {
+                folderLi.classList.remove('closed');
+                syncFolderExpandedAria(folderLi);
+            }
             parent = folderLi?.parentElement.closest('.nested-list');
         }
     } else if (activeFolderHeader) {
         activeFolderHeader.classList.add('active');
         const folderLi = activeFolderHeader.closest('.folder');
-        if (folderLi && folderLi.classList.contains('closed')) folderLi.classList.remove('closed');
+        if (folderLi && folderLi.classList.contains('closed')) {
+            folderLi.classList.remove('closed');
+            syncFolderExpandedAria(folderLi);
+        }
     }
 
     currentlyLoadedMapId = mapId;
@@ -2397,72 +2416,131 @@ function updateVisibleRegions() {
 }
 
 // --- Populate Sidebar (Recursive Function) ---
-function populateSidebar(parentElement, items) {
-    // Add this log at the start of the function
+function syncFolderExpandedAria(folderListItem) {
+    if (!folderListItem) return;
+    const header = folderListItem.querySelector('.folder-header');
+    if (!header) return;
+    const expanded = !folderListItem.classList.contains('closed');
+    const expandedText = expanded ? 'true' : 'false';
+    const toggleBtn = header.querySelector('.folder-toggle-btn');
+    const mainAction = header.querySelector('.folder-main-action');
+    if (toggleBtn) toggleBtn.setAttribute('aria-expanded', expandedText);
+    if (mainAction) mainAction.setAttribute('aria-expanded', expandedText);
+}
 
+function populateSidebar(parentElement, items) {
     parentElement.innerHTML = '';
     items.forEach(item => {
-        // Add this log inside the loop
-
         const listItem = document.createElement('li');
 
         if (item.type === 'folder') {
-            // Add this log for folders
-
             listItem.classList.add('folder', 'closed');
             const header = document.createElement('div');
             header.classList.add('folder-header');
-            header.tabIndex = 0;
-            header.setAttribute('role', 'button');
-            // This line includes the fix from before
-            header.innerHTML = `<span class="folder-toggle-icon"></span><span>${item.name || 'Unnamed Folder!'}</span>`; // Add fallback text
+            const folderName = item.name || 'Unnamed Folder!';
+            const hasChildren = Array.isArray(item.children) && item.children.length > 0;
+            const isComingSoon = item.status === 'coming-soon';
+            const isLoadable = !!item.id && !isComingSoon;
+
+            const toggleBtn = document.createElement('button');
+            toggleBtn.type = 'button';
+            toggleBtn.className = 'folder-toggle-btn';
+            toggleBtn.setAttribute('aria-label', `Toggle folder: ${folderName}`);
+            toggleBtn.innerHTML = `
+                <span class="sidebar-chevron-icon" aria-hidden="true">
+                    <i class="ui-icon" data-lucide="chevron-right"></i>
+                </span>
+            `;
+            if (!hasChildren) {
+                toggleBtn.disabled = true;
+                toggleBtn.setAttribute('aria-hidden', 'true');
+                toggleBtn.tabIndex = -1;
+            }
+
+            const mainAction = document.createElement('button');
+            mainAction.type = 'button';
+            mainAction.className = 'folder-main-action';
+            if (isLoadable) {
+                const loadIcon = document.createElement('span');
+                loadIcon.className = 'folder-load-icon';
+                loadIcon.setAttribute('aria-hidden', 'true');
+                loadIcon.innerHTML = `<i class="ui-icon" data-lucide="map-pin"></i>`;
+                mainAction.appendChild(loadIcon);
+            }
+            const mainActionLabel = document.createElement('span');
+            mainActionLabel.className = 'folder-main-action-label';
+            mainActionLabel.textContent = `${folderName}${isComingSoon ? ' (Soon)' : ''}`;
+            mainAction.appendChild(mainActionLabel);
+
             const nestedList = document.createElement('ul');
             nestedList.classList.add('nested-list');
 
-            if (item.children && item.children.length > 0) {
-                // Log before recursion
+            if (hasChildren) {
                 populateSidebar(nestedList, item.children);
-            } else {
-                // Log if no children
             }
 
-            header.addEventListener('click', (e) => {
+            const toggleFolderOpen = (e) => {
                 e.stopPropagation();
+                if (!hasChildren) return;
                 listItem.classList.toggle('closed');
-            });
-            header.addEventListener('keydown', (e) => {
+                syncFolderExpandedAria(listItem);
+            };
+
+            toggleBtn.addEventListener('click', toggleFolderOpen);
+            toggleBtn.addEventListener('keydown', (e) => {
                 if (e.key === 'Enter' || e.key === ' ') {
                     e.preventDefault();
-                    header.click();
+                    toggleFolderOpen(e);
                 }
             });
 
-            if (item.id && item.status !== 'coming-soon') {
+            if (isLoadable) {
                 header.dataset.mapId = item.id;
-                header.title = `Click to toggle '${item.name}', double-click to load map.`;
-                header.addEventListener('dblclick', (e) => {
+                mainAction.title = `Load map: ${folderName}`;
+                mainAction.setAttribute('aria-label', `Load map: ${folderName}`);
+                mainAction.addEventListener('click', (e) => {
                     e.stopPropagation();
                     unlockAdvancedControls('map_selected');
                     loadMap(item.id, true);
                 });
-            } else if (item.status === 'coming-soon') {
+                mainAction.addEventListener('keydown', (e) => {
+                    if (e.key === 'Enter' || e.key === ' ') {
+                        e.preventDefault();
+                        mainAction.click();
+                    }
+                });
+            } else if (isComingSoon) {
                 header.classList.add('coming-soon');
-                // Apply the (Soon) text suffix and title
-                header.innerHTML = `<span class="folder-toggle-icon"></span><span>${item.name || 'Unnamed Folder!'} (Soon)</span>`;
-                header.title = `${item.name || 'Coming Soon!'} - Coming Soon!`;
-                header.addEventListener('dblclick', (e) => {
+                mainAction.title = `${folderName} - Coming Soon!`;
+                mainAction.setAttribute('aria-label', `${folderName} coming soon`);
+                mainAction.addEventListener('click', (e) => {
                     e.stopPropagation();
-                    alert(`The map "${item.name || 'this map'}" is coming soon!`);
+                    alert(`The map "${folderName}" is coming soon!`);
+                });
+                mainAction.addEventListener('keydown', (e) => {
+                    if (e.key === 'Enter' || e.key === ' ') {
+                        e.preventDefault();
+                        mainAction.click();
+                    }
                 });
             } else {
-                header.title = `Click to toggle '${item.name || 'Unnamed Folder!'}'.`;
+                mainAction.title = `Toggle folder: ${folderName}`;
+                mainAction.setAttribute('aria-label', `Toggle folder: ${folderName}`);
+                mainAction.addEventListener('click', toggleFolderOpen);
+                mainAction.addEventListener('keydown', (e) => {
+                    if (e.key === 'Enter' || e.key === ' ') {
+                        e.preventDefault();
+                        toggleFolderOpen(e);
+                    }
+                });
             }
+            syncFolderExpandedAria(listItem);
+            header.appendChild(toggleBtn);
+            header.appendChild(mainAction);
             listItem.appendChild(header);
             listItem.appendChild(nestedList);
 
         } else { // Map Item
-            // Add this log for map items
-
             listItem.classList.add('map-item');
             listItem.textContent = item.name || 'Unnamed Map!'; // Add fallback text
             listItem.dataset.mapId = item.id;
@@ -2500,6 +2578,7 @@ function populateSidebar(parentElement, items) {
         }
         parentElement.appendChild(listItem);
     });
+    refreshLucideIcons();
 }
 // populateSidebar is now called within initializeApp after data is loaded
 
@@ -2667,12 +2746,18 @@ function addRoadsToMap(mapId) {
 }
 
 function initializeSoundState() {
+    const setSoundIcon = (enabled) => {
+        if (!soundIcon) return;
+        soundIcon.innerHTML = `<i class="ui-icon" data-lucide="${enabled ? 'volume-2' : 'volume-x'}" aria-hidden="true"></i>`;
+        refreshLucideIcons();
+    };
+
     // --- NEW: Check for embedded mode ---
     const urlParams = getUrlParameters(); // Need to get params here too
     if (urlParams.embed === 'true' || urlParams.hideUI === 'true') {
         soundEnabled = false; // Ensure state reflects no sound
         // Set icon/title to muted state (even though button is hidden)
-        soundIcon.innerHTML = `<svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polygon points="11 5 6 9 2 9 2 15 6 15 11 19 11 5"/><line x1="23" x2="17" y1="9" y2="15"/><line x1="17" x2="23" y1="9" y2="15"/></svg>`;
+        setSoundIcon(false);
         if (toggleSoundBtn) toggleSoundBtn.title = "Unmute Sound"; // Check if button exists before setting title
         return; // Exit early, do not proceed with sound logic
     }
@@ -2689,7 +2774,7 @@ function initializeSoundState() {
     darkAmbient.volume = 0;
 
     if (soundEnabled && canUseSoundNow) {
-        soundIcon.innerHTML = `<svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polygon points="11 5 6 9 2 9 2 15 6 15 11 19 11 5"/><path d="M15.54 8.46a5 5 0 0 1 0 7.07"/><path d="M19.07 4.93a10 10 0 0 1 0 14.14"/></svg>`;
+        setSoundIcon(true);
             if (toggleSoundBtn) {
                 toggleSoundBtn.title = "Mute Sound";
                 toggleSoundBtn.setAttribute('aria-label', "Mute Sound");
@@ -2705,7 +2790,7 @@ function initializeSoundState() {
     } else {
         fadeAudio(lightAmbient, 0);
         fadeAudio(darkAmbient, 0);
-        soundIcon.innerHTML = `<svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polygon points="11 5 6 9 2 9 2 15 6 15 11 19 11 5"/><line x1="23" x2="17" y1="9" y2="15"/><line x1="17" x2="23" y1="9" y2="15"/></svg>`;
+        setSoundIcon(false);
         if (toggleSoundBtn) {
             toggleSoundBtn.title = "Unmute Sound";
             toggleSoundBtn.setAttribute('aria-label', "Unmute Sound");
@@ -2724,7 +2809,8 @@ if (toggleSoundBtn) {
         safeSetStorage(UX_STORAGE_KEYS.soundEnabled, String(soundEnabled));
 
         if (soundEnabled) {
-            soundIcon.innerHTML = `<svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polygon points="11 5 6 9 2 9 2 15 6 15 11 19 11 5"/><path d="M15.54 8.46a5 5 0 0 1 0 7.07"/><path d="M19.07 4.93a10 10 0 0 1 0 14.14"/></svg>`;
+            soundIcon.innerHTML = `<i class="ui-icon" data-lucide="volume-2" aria-hidden="true"></i>`;
+            refreshLucideIcons();
             toggleSoundBtn.title = "Mute Sound";
             toggleSoundBtn.setAttribute('aria-label', "Mute Sound");
             toggleSoundBtn.setAttribute('aria-pressed', "true");
@@ -2736,7 +2822,8 @@ if (toggleSoundBtn) {
                 fadeAudio(lightAmbient, 0.3);
             }
         } else {
-            soundIcon.innerHTML = `<svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polygon points="11 5 6 9 2 9 2 15 6 15 11 19 11 5"/><line x1="23" x2="17" y1="9" y2="15"/><line x1="17" x2="23" y1="9" y2="15"/></svg>`;
+            soundIcon.innerHTML = `<i class="ui-icon" data-lucide="volume-x" aria-hidden="true"></i>`;
+            refreshLucideIcons();
             toggleSoundBtn.title = "Unmute Sound";
             toggleSoundBtn.setAttribute('aria-label', "Unmute Sound");
             toggleSoundBtn.setAttribute('aria-pressed', "false");


### PR DESCRIPTION
### Summary
This PR replaces hand-authored/mixed SVG icons with a standardized Lucide icon set, improves sidebar folder interactions, and fixes icon alignment within control/button containers.

### What Changed

#### 1. Switched to Lucide icon pack
- Added Lucide browser script and converted static control icons to `data-lucide` placeholders.
- Replaced ad-hoc inline SVGs for:
  - map controls
  - sidebar toggle
  - coordinate copy/copy-success icons
  - folder chevrons/load indicator
  - filter group chevrons
  - popup action icons (share, linked map jump)
  - sound toggle state icons

#### 2. Added icon rehydration for dynamic UI
- Introduced a helper to call `lucide.createIcons()` after dynamic DOM updates.
- Hooked into:
  - sidebar state icon changes
  - sidebar population
  - filter population
  - popup open events
  - runtime sound icon swaps

#### 3. Clarified folder interaction model
- Removed folder double-click behavior.
- Folder rows now have explicit interaction zones:
  - chevron toggle button for expand/collapse
  - main action for load/select (when folder is loadable)
- Preserved coming-soon behavior and keyboard accessibility.

#### 4. Improved icon centering/alignment
- Adjusted control button CSS to consistently center Lucide icons.
- Fixed alignment in:
  - map control button stack
  - sidebar collapse/expand button
  - copy coordinates control