### PR TITLE
Fix blank map preview in Map Editor

### DIFF
--- a/css/map-editor.css
+++ b/css/map-editor.css
@@ -5,8 +5,9 @@
 }
 
 .map-editor-body {
+    overflow: hidden;
     margin: 0;
-    min-height: 100vh;
+    height: 100vh;
     font-family: "EB Garamond", serif;
     background:
         radial-gradient(circle at top left, color-mix(in srgb, var(--highlight-bg) 58%, transparent), transparent 45%),
@@ -15,7 +16,7 @@
 }
 
 .map-editor-shell {
-    min-height: 100vh;
+    height: 100vh;
     display: grid;
     grid-template-columns: minmax(250px, 280px) minmax(0, 1fr) minmax(320px, 380px);
     gap: 0;
@@ -24,7 +25,7 @@
 .map-editor-sidebar,
 .map-editor-inspector,
 .map-editor-canvas-panel {
-    min-height: 100vh;
+    height: 100vh;
 }
 
 .map-editor-sidebar,
@@ -37,6 +38,7 @@
 
 .map-editor-sidebar {
     border-right: 1px solid var(--editor-panel-border);
+    overflow-y: auto;
 }
 
 .map-editor-inspector {


### PR DESCRIPTION
Fixes a layout bug in `map-editor.html` where the map preview wouldn't appear because `min-height` sizing rules allowed internal Leaflet containers to stretch endlessly offscreen. Constraints have been added so the editor bounds strictly match the viewport height, and side panels scroll independently.

---
*PR created automatically by Jules for task [6939590896409742031](https://jules.google.com/task/6939590896409742031) started by @jaxsnjohnson*