### PR TITLE
Refactor map editor UX flow and fix underlay rendering bug

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 .DS_Store
+node_modules

--- a/css/map-editor.css
+++ b/css/map-editor.css
@@ -18,8 +18,23 @@
 .map-editor-shell {
     height: 100vh;
     display: grid;
-    grid-template-columns: minmax(250px, 280px) minmax(0, 1fr) minmax(320px, 380px);
+    grid-template-columns: minmax(0, 1fr) minmax(320px, 380px);
     gap: 0;
+}
+
+.map-editor-shell[data-mode="select"] {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+}
+
+.map-editor-shell[data-mode="select"] .map-editor-canvas-panel,
+.map-editor-shell[data-mode="select"] .map-editor-inspector {
+    display: none;
+}
+
+.map-editor-shell[data-mode="edit"] .map-editor-sidebar {
+    display: none;
 }
 
 .map-editor-sidebar,
@@ -37,8 +52,14 @@
 }
 
 .map-editor-sidebar {
-    border-right: 1px solid var(--editor-panel-border);
+    border: 1px solid var(--editor-panel-border);
+    border-radius: 12px;
     overflow-y: auto;
+    width: 100%;
+    max-width: 400px;
+    height: auto;
+    max-height: 80vh;
+    box-shadow: 0 4px 20px rgba(0, 0, 0, 0.1);
 }
 
 .map-editor-inspector {

--- a/js/map-editor.js
+++ b/js/map-editor.js
@@ -28,6 +28,7 @@
     };
 
     const dom = {
+        appShell: document.getElementById('map-editor-app'),
         atlasTree: document.getElementById('editor-atlas-tree'),
         treeSearch: document.getElementById('editor-tree-search'),
         reloadButton: document.getElementById('reload-editor-btn'),
@@ -54,7 +55,8 @@
         deleteSelectionButton: document.getElementById('editor-delete-selection-btn'),
         resetViewButton: document.getElementById('editor-reset-view-btn'),
         exportCurrentMapButton: document.getElementById('export-current-map-btn'),
-        exportAtlasStructureButton: document.getElementById('export-atlas-structure-btn')
+        exportAtlasStructureButton: document.getElementById('export-atlas-structure-btn'),
+        chooseMapButton: document.getElementById('editor-choose-map-btn')
     };
 
     function roundCoordinate(value) {
@@ -800,7 +802,8 @@
                 fill: true,
                 fillOpacity: 1,
                 fillColor: state.currentMap.backgroundColor || '#0f172a',
-                interactive: false
+                interactive: false,
+                pane: 'tilePane'
             }).addTo(state.map);
             setMapEmptyState({
                 hidden: false,
@@ -1083,6 +1086,9 @@
         setSelectionStatus(`Editing "${state.currentMap.name || state.currentMap.id}".`);
         renderMapLayers(true);
         setExportStatus('');
+
+        dom.appShell.setAttribute('data-mode', 'edit');
+        queueMapViewportReset();
     }
 
     function initializeMap() {
@@ -1146,6 +1152,11 @@
                 queueMapViewportReset();
             }
         });
+        if (dom.chooseMapButton) {
+            dom.chooseMapButton.addEventListener('click', () => {
+                dom.appShell.setAttribute('data-mode', 'select');
+            });
+        }
         dom.exportCurrentMapButton.addEventListener('click', exportCurrentMapJson);
         dom.exportAtlasStructureButton.addEventListener('click', exportAtlasStructure);
     }

--- a/map-editor.html
+++ b/map-editor.html
@@ -51,7 +51,7 @@
     </script>
 </head>
 <body class="map-editor-body">
-    <div id="map-editor-app" class="map-editor-shell">
+    <div id="map-editor-app" class="map-editor-shell" data-mode="select">
         <aside class="map-editor-sidebar">
             <div class="map-editor-panel-header">
                 <div>
@@ -70,6 +70,7 @@
         <main class="map-editor-canvas-panel">
             <div class="map-editor-toolbar">
                 <div class="map-editor-toolbar-group">
+                    <button id="editor-choose-map-btn" type="button">⬅ Choose Map</button>
                     <button id="editor-add-poi-btn" type="button">Add POI</button>
                     <button id="editor-add-region-btn" type="button">Draw Region</button>
                     <button id="editor-add-line-btn" type="button">Draw Line</button>


### PR DESCRIPTION
This commit fixes the blue rectangle rendering issue in `map-editor.html` and introduces a two-step "Select Map -> Edit Map" UX flow.

**Fixes:**
* Assigned the map bounds underlay (`L.rectangle`) to `pane: 'tilePane'` in `js/map-editor.js`. This guarantees that it renders *below* the map's image overlay (which renders in `overlayPane`), fixing the bug where a blue rectangle obscured the map image.

**Features/Refactoring:**
* Introduced a state-driven UI layout in `map-editor.html` using a `data-mode` attribute on `.map-editor-shell`.
* `data-mode="select"`: Displays the sidebar centered for selecting a map, and hides the map canvas and inspector.
* `data-mode="edit"`: Hides the sidebar and expands the map canvas and inspector for full-screen editing.
* Added a "⬅ Choose Map" button (`#editor-choose-map-btn`) to the map canvas toolbar to easily return to the selection state.
* The editor automatically transitions to `edit` mode when a map is selected or explicitly loaded via URL.

---
*PR created automatically by Jules for task [659315382352814526](https://jules.google.com/task/659315382352814526) started by @jaxsnjohnson*