### PR TITLE
Make map editor inspector sections collapsible

### DIFF
--- a/css/map-editor.css
+++ b/css/map-editor.css
@@ -83,9 +83,32 @@
     gap: 12px;
 }
 
+.map-editor-section-header {
+    cursor: pointer;
+    user-select: none;
+    list-style: none; /* remove native triangle on most browsers */
+}
+
+.map-editor-section-header::-webkit-details-marker {
+    display: none; /* remove native triangle on Safari */
+}
+
 .map-editor-panel-header h1,
 .map-editor-section-header h2 {
     margin: 0;
+    display: flex;
+    align-items: center;
+    gap: 8px;
+}
+
+.map-editor-section-header h2::before {
+    content: "▶";
+    font-size: 0.8em;
+    transition: transform 0.2s ease-in-out;
+}
+
+details[open] .map-editor-section-header h2::before {
+    transform: rotate(90deg);
 }
 
 .map-editor-eyebrow {

--- a/map-editor.html
+++ b/map-editor.html
@@ -102,11 +102,11 @@
         </main>
 
         <aside class="map-editor-inspector">
-            <section class="map-editor-section">
-                <div class="map-editor-section-header">
+            <details class="map-editor-section" open>
+                <summary class="map-editor-section-header">
                     <h2>Map Metadata</h2>
                     <span id="editor-current-map-id" class="map-editor-chip">No map</span>
-                </div>
+                </summary>
 
                 <form id="map-settings-form" class="map-editor-form">
                     <label>Name<input id="map-name-input" name="name" type="text"></label>
@@ -138,13 +138,13 @@
                         <textarea id="map-blurb-input" name="blurb" rows="5"></textarea>
                     </label>
                 </form>
-            </section>
+            </details>
 
-            <section class="map-editor-section">
-                <div class="map-editor-section-header">
+            <details class="map-editor-section" open>
+                <summary class="map-editor-section-header">
                     <h2>Features</h2>
                     <span id="editor-feature-summary" class="map-editor-chip">0 selected</span>
-                </div>
+                </summary>
 
                 <div class="map-editor-feature-columns">
                     <div>
@@ -160,19 +160,19 @@
                         <div id="editor-line-list" class="map-editor-feature-list"></div>
                     </div>
                 </div>
-            </section>
+            </details>
 
-            <section class="map-editor-section">
-                <div class="map-editor-section-header">
+            <details class="map-editor-section" open>
+                <summary class="map-editor-section-header">
                     <h2>Selected Feature</h2>
                     <span id="editor-selected-feature-chip" class="map-editor-chip">None</span>
-                </div>
+                </summary>
 
                 <div id="editor-feature-inspector-empty" class="map-editor-placeholder">
                     Select a POI, region, or line to edit its fields.
                 </div>
                 <form id="editor-feature-form" class="map-editor-form" hidden></form>
-            </section>
+            </details>
         </aside>
     </div>
 


### PR DESCRIPTION
Converted the Map Editor's inspector panel sections (Map Metadata, Features, Selected Feature) to use native HTML `<details>` and `<summary>` elements, allowing them to be collapsed. This makes the interface more manageable on smaller screens and reduces visual clutter. Added custom CSS styling to replace the default disclosure triangles with a custom rotating chevron.

---
*PR created automatically by Jules for task [6084675533100939545](https://jules.google.com/task/6084675533100939545) started by @jaxsnjohnson*