### PR TITLE
fix: restore visibility of regions missing type or value

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -5023,10 +5023,12 @@ function updateVisibleRegions() {
 
     currentRegionGroup.eachLayer(layer => {
         const region = layer.regionData;
-        if (!region || !region.type || !region.value) return;
+        if (!region) return;
+
+        const regionFilterValue = region.value || region.name;
 
         // A region is visible if the master toggle is checked OR its specific value is in the checked set.
-        const typeMatch = allTypesChecked || valueFilterValues.has(region.value);
+        const typeMatch = allTypesChecked || valueFilterValues.has(regionFilterValue);
 
         // Apply visibility and interactivity based on *both* the overall toggle AND the type filter match
         if (regionsVisible && typeMatch) { // regionsVisible is synced with markersVisible


### PR DESCRIPTION
This fixes an issue where regions mapped in the JSON files (like `Arfordir.json`) were not appearing on the map despite lines working correctly. The root cause was an overly strict check in `updateVisibleRegions()` in `js/app.js` requiring both `type` and `value` to be present. Using `name` as a fallback allows these regions to display correctly again. Tested successfully.

---
*PR created automatically by Jules for task [6390678515167424916](https://jules.google.com/task/6390678515167424916) started by @jaxsnjohnson*