### PR TITLE
fix: ensure regions are visible by default on map load

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -15,7 +15,7 @@ let mapData = []; // Will be populated by loadMapData
 let loadingProgressInterval = null;
 let loadingProgress = 0;
 let currentRegionGroup = null;
-let regionsVisible = false; // Overall region visibility toggle
+let regionsVisible = true; // Overall region visibility toggle
 let currentRoadGroup = null; // Holds currently displayed road layers (and lines)
 // let regionFiltersPanelVisible = false; // No longer needed as separate panel
 


### PR DESCRIPTION
# Description
Fixed an issue where regions mapped in the JSON data were not appearing on the map initially, requiring users to manually toggle the "Hide Markers and Regions" button off and on to render them. This was caused by `regionsVisible` incorrectly being initialized to `false` in `js/app.js`, while `markersVisible` was `true`. Changing `regionsVisible` to `true` resolves the visibility mismatch and properly renders regions immediately upon map load.

# Tests done
- Ran `bun test` repository tests cleanly.
- Wrote a Playwright web UI script testing the loaded DOM nodes. Confirmed `leaflet-interactive` `path` elements correctly render onto the initial map load without toggling visibility.
- Verified visual output with a screenshot.

---
*PR created automatically by Jules for task [9410651493028030247](https://jules.google.com/task/9410651493028030247) started by @jaxsnjohnson*