### PR TITLE
🎨 Palette: Enhance Map Chooser accessibility and focus states

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,0 +1,7 @@
+## 2023-10-27 - Map Chooser Screen Reader Metadata
+**Learning:** Using a single overriding `aria-label` on complex map cards masks rich internal content (like edit dates, descriptions, and regions) from screen readers.
+**Action:** When a UI component contains rich inner metadata, use dynamically generated IDs bound via `aria-labelledby` and `aria-describedby` to safely expose its full context.
+
+## 2023-10-27 - Archive <summary> Focus and Hover States
+**Learning:** Native HTML `<summary>` tags often lack visual feedback (focus rings, hover colors) in custom design systems, severely degrading keyboard accessibility and mouse discoverability.
+**Action:** Always ensure custom-styled summary elements receive the global `:focus-visible` ring and a subtle hover transition state.

--- a/css/style.css
+++ b/css/style.css
@@ -531,7 +531,8 @@ input:focus-visible,
 .map-item:focus-visible,
 .folder-toggle-btn:focus-visible,
 .folder-main-action:focus-visible,
-.search-result-item:focus-visible {
+.search-result-item:focus-visible,
+.map-chooser-archive-summary:focus-visible {
     outline: 2px solid var(--focus-ring);
     outline-offset: 2px;
 }
@@ -3418,6 +3419,12 @@ html.mobile-layout-v2.map-interacting #map-blurb {
     align-items: center;
     gap: 8px;
     user-select: none;
+    border-radius: 4px;
+    transition: color 0.2s ease;
+}
+
+.map-chooser-archive-summary:hover {
+    color: #f6f3ff;
 }
 
 .map-chooser-archive-summary::before {

--- a/js/app.js
+++ b/js/app.js
@@ -1765,7 +1765,15 @@ function createMapChooserCard(mapInfo, index, activeMapId) {
     const isActive = mapInfo.id === activeMapId;
     card.classList.toggle('is-active', isActive);
     if (isActive) card.setAttribute('aria-current', 'page');
-    card.setAttribute('aria-label', `Open map: ${mapName}`);
+
+    const baseId = `map-card-${mapInfo.id.replace(/\W/g, '-')}-${index}`;
+    const titleId = `${baseId}-title`;
+    const descId = `${baseId}-desc`;
+    const editedId = `${baseId}-edited`;
+    const regionsId = `${baseId}-regions`;
+
+    card.setAttribute('aria-labelledby', titleId);
+    card.setAttribute('aria-describedby', `${descId} ${editedId} ${regionsId}`);
 
     const media = document.createElement('span');
     media.className = 'map-chooser-card-media';
@@ -1786,18 +1794,22 @@ function createMapChooserCard(mapInfo, index, activeMapId) {
     copy.className = 'map-chooser-card-copy';
 
     const title = document.createElement('span');
+    title.id = titleId;
     title.className = 'map-chooser-card-title';
     title.textContent = mapName;
 
     const edited = document.createElement('span');
+    edited.id = editedId;
     edited.className = 'map-chooser-meta map-chooser-edited';
     edited.textContent = `Last edited: ${formatMapChooserDate(mapInfo.updatedAt, mapInfo.lastEdited, mapInfo.modifiedAt, atlasGeneratedAt)}`;
 
     const regions = document.createElement('span');
+    regions.id = regionsId;
     regions.className = 'map-chooser-meta map-chooser-regions';
     regions.textContent = 'Regions: ...';
 
     const description = document.createElement('span');
+    description.id = descId;
     description.className = 'map-chooser-meta map-chooser-description';
     description.textContent = String(mapInfo.summary || mapInfo.description || '').trim();
     if (!description.textContent) {


### PR DESCRIPTION
💡 What:
- Added dynamic `aria-labelledby` and `aria-describedby` logic to Map Chooser cards so they broadcast their rich metadata correctly.
- Added standard focus ring and hover states to the "Archive Maps" `<summary>` element.

🎯 Why:
- Previous implementation masked rich text like regions, descriptions, and edit dates under a generic screen reader label.
- The archive folder was missing visual affordances for keyboard navigators and mouse users.

♿ Accessibility:
- Screen readers will now comprehensively narrate map card features.
- Keyboard users now have a visual indicator when tabbing to the Archive section.

---
*PR created automatically by Jules for task [9759107762928090556](https://jules.google.com/task/9759107762928090556) started by @jaxsnjohnson*