### PR TITLE
🎨 Palette: [UX improvement] Hide redundant map chooser images from screen readers

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -5,3 +5,7 @@
 ## 2023-10-27 - Archive <summary> Focus and Hover States
 **Learning:** Native HTML `<summary>` tags often lack visual feedback (focus rings, hover colors) in custom design systems, severely degrading keyboard accessibility and mouse discoverability.
 **Action:** Always ensure custom-styled summary elements receive the global `:focus-visible` ring and a subtle hover transition state.
+
+## 2026-04-29 - Map Chooser Image Accessibility
+**Learning:** Images inside interactive components like buttons that already provide rich text context via `aria-labelledby` cause redundant and noisy screen reader announcements if they retain their descriptive `alt` text.
+**Action:** Set the image `alt` attribute to an empty string (`alt=''`) and add `aria-hidden='true'` to explicitly hide decorative or redundant images from the accessibility tree when the parent component already provides the necessary context.

--- a/js/app.js
+++ b/js/app.js
@@ -1780,7 +1780,8 @@ function createMapChooserCard(mapInfo, index, activeMapId) {
 
     const image = document.createElement('img');
     const imageSources = getMapChooserImageSources(mapInfo);
-    image.alt = `${mapName} map preview`;
+    image.alt = '';
+    image.setAttribute('aria-hidden', 'true');
     image.loading = index < 3 ? 'eager' : 'lazy';
     image.decoding = 'async';
     if (imageSources.fallback && imageSources.fallback !== imageSources.preview) {


### PR DESCRIPTION
🎨 Palette: [UX improvement] Hide redundant map chooser images from screen readers

💡 What: Removed `alt` text and added `aria-hidden="true"` to map preview images in the map chooser cards.
🎯 Why: The map chooser cards (buttons) already announce their full context via `aria-labelledby` and `aria-describedby` (including the map name, description, etc). Having descriptive `alt` text on the image caused screen readers to redundantly announce "Map Name map preview" alongside the button's name, creating a noisy user experience.
♿ Accessibility: Improves screen reader clarity by explicitly hiding redundant decorative elements from the accessibility tree.

---
*PR created automatically by Jules for task [14350789733648394784](https://jules.google.com/task/14350789733648394784) started by @jaxsnjohnson*