### PR TITLE
⚡ Bolt: Prevent unnecessary layer iteration during filtering

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -17,3 +17,7 @@
 ## 2025-05-27 - Debouncing Feature Form Input in Map Editor
 **Learning:** Similar to search inputs in `app.js` and `map-editor.js`, the `featureForm` in the map editor called `updateSelectedFeatureFromForm` on every keystroke (`input` event). This caused a full re-render of feature lists (`renderFeatureLists`) and map layers (`renderMapLayers(false)`) on each character typed in properties like `coordY`, `coordX`, `color`, `weight`, etc., causing noticeable UI lag on complex maps.
 **Action:** Identify forms or specific input fields that trigger synchronous DOM-heavy re-renders and proactively apply a `debounce` wrapper (e.g., 300ms) to their `input` event handlers to batch execution while maintaining the immediate `change` event for final confirmation (e.g., on blur).
+
+## 2024-05-27 - Skipping Unnecessary Layer Iteration
+**Learning:** In combined filter-and-search loops (like `updateVisibleMarkersAndSearch`), iterating over entire layer collections (like regions and lines) and extracting properties for search evaluation is extremely expensive on large maps, even if the fuzzy matching string manipulation itself is conditionally skipped.
+**Action:** When evaluating search results, hoist the conditional check for whether search is active (`if (searchFiltersCurrentMap)`) completely *outside* the `.eachLayer()` loops for map features whose visibility is handled elsewhere (like regions and lines). This turns an O(N) operation into an O(1) bypass when the user is only toggling filters.

--- a/js/app.js
+++ b/js/app.js
@@ -3378,33 +3378,35 @@ function updateVisibleMarkersAndSearch() {
     });
     const allRegionTypesChecked = filterToggleAllCheckbox.checked && !filterToggleAllCheckbox.indeterminate;
 
-    if (currentRegionGroup) {
-        currentRegionGroup.eachLayer((layer) => {
-            const region = layer.regionData;
-            if (!region || !region.name) return;
+    if (searchFiltersCurrentMap) {
+        if (currentRegionGroup) {
+            currentRegionGroup.eachLayer((layer) => {
+                const region = layer.regionData;
+                if (!region || !region.name) return;
 
-            const regionFilterValue = region.value || region.name;
-            const typeMatch = allRegionTypesChecked || activeRegionTypeFilters.has(regionFilterValue);
+                const regionFilterValue = region.value || region.name;
+                const typeMatch = allRegionTypesChecked || activeRegionTypeFilters.has(regionFilterValue);
 
-            // ⚡ Bolt: Skip expensive string concatenation and fuzzy matching when the user is only filtering (search is empty).
-            if (searchFiltersCurrentMap && typeMatch) {
-                const match = computeSearchMatch(searchTerm, region.name, `${region.summary || ''} ${region.description || ''}`);
+                // ⚡ Bolt: Skip expensive string concatenation and fuzzy matching when the user is only filtering (search is empty).
+                if (typeMatch) {
+                    const match = computeSearchMatch(searchTerm, region.name, `${region.summary || ''} ${region.description || ''}`);
 
-                if (match.matched) {
-                    results.push({
-                        group: 'region',
-                        badge: 'Region',
-                        title: region.name,
-                        subtitle: match.matchedByContent ? `Matched in ${region.type || 'region'} description` : (region.value || region.type || 'Region'),
-                        score: match.score,
-                        onSelect: () => {
-                            map.fitBounds(layer.getBounds(), { maxZoom: Math.max(map.getZoom(), 1) });
-                            layer.openPopup();
-                        }
-                    });
+                    if (match.matched) {
+                        results.push({
+                            group: 'region',
+                            badge: 'Region',
+                            title: region.name,
+                            subtitle: match.matchedByContent ? `Matched in ${region.type || 'region'} description` : (region.value || region.type || 'Region'),
+                            score: match.score,
+                            onSelect: () => {
+                                map.fitBounds(layer.getBounds(), { maxZoom: Math.max(map.getZoom(), 1) });
+                                layer.openPopup();
+                            }
+                        });
+                    }
                 }
-            }
-        });
+            });
+        }
     }
 
     const activeLineTypeFilters = new Set();
@@ -3413,33 +3415,35 @@ function updateVisibleMarkersAndSearch() {
     });
     const allLineTypesChecked = filterToggleAllCheckbox.checked && !filterToggleAllCheckbox.indeterminate;
 
-    if (currentRoadGroup) {
-        currentRoadGroup.eachLayer((layer) => {
-            const line = layer.roadData;
-            if (!line) return;
-            const lineName = line.name || line.type || 'Unnamed Line';
-            const lineType = line.type || 'Unnamed Road Type';
-            const typeMatch = allLineTypesChecked || activeLineTypeFilters.has(lineType);
+    if (searchFiltersCurrentMap) {
+        if (currentRoadGroup) {
+            currentRoadGroup.eachLayer((layer) => {
+                const line = layer.roadData;
+                if (!line) return;
+                const lineName = line.name || line.type || 'Unnamed Line';
+                const lineType = line.type || 'Unnamed Road Type';
+                const typeMatch = allLineTypesChecked || activeLineTypeFilters.has(lineType);
 
-            // ⚡ Bolt: Skip expensive string concatenation and fuzzy matching when the user is only filtering (search is empty).
-            if (searchFiltersCurrentMap && typeMatch) {
-                const match = computeSearchMatch(searchTerm, lineName, `${lineType} ${line.summary || ''} ${line.description || ''}`);
+                // ⚡ Bolt: Skip expensive string concatenation and fuzzy matching when the user is only filtering (search is empty).
+                if (typeMatch) {
+                    const match = computeSearchMatch(searchTerm, lineName, `${lineType} ${line.summary || ''} ${line.description || ''}`);
 
-                if (match.matched) {
-                    results.push({
-                        group: 'line',
-                        badge: 'Line',
-                        title: lineName,
-                        subtitle: match.matchedByContent ? `Matched in ${lineType.toLowerCase()} details` : lineType,
-                        score: match.score,
-                        onSelect: () => {
-                            map.fitBounds(layer.getBounds(), { maxZoom: Math.max(map.getZoom(), 1) });
-                            if (layer.getPopup()) layer.openPopup();
-                        }
-                    });
+                    if (match.matched) {
+                        results.push({
+                            group: 'line',
+                            badge: 'Line',
+                            title: lineName,
+                            subtitle: match.matchedByContent ? `Matched in ${lineType.toLowerCase()} details` : lineType,
+                            score: match.score,
+                            onSelect: () => {
+                                map.fitBounds(layer.getBounds(), { maxZoom: Math.max(map.getZoom(), 1) });
+                                if (layer.getPopup()) layer.openPopup();
+                            }
+                        });
+                    }
                 }
-            }
-        });
+            });
+        }
     }
 
     if (searchFiltersCurrentMap && currentRoutes && currentRoutes.length > 0) {


### PR DESCRIPTION
💡 What: Hoisted the `if (searchFiltersCurrentMap)` conditional check to completely wrap the `currentRegionGroup.eachLayer`, `currentRoadGroup.eachLayer`, and `currentRoutes.forEach` loops in `updateVisibleMarkersAndSearch`.
🎯 Why: Previously, filtering logic iterated over all region and line layers, evaluating conditions inside the loop even when the user was just toggling a category filter and not using the search input. This optimization bypasses those O(N) operations entirely when search is inactive.
📊 Impact: Eliminates unnecessary iteration over hundreds of map features during simple filter toggles, noticeably reducing UI lag on complex maps with many regions and lines.
🔬 Measurement: Open a large map with many lines/regions and toggle the filter categories. The UI will no longer execute the iteration overhead for non-POIs.

---
*PR created automatically by Jules for task [16811895865309202278](https://jules.google.com/task/16811895865309202278) started by @jaxsnjohnson*