### PR TITLE
Remove FIX prefix from generateHash history state comment

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -2690,7 +2690,7 @@ function setSidebarState(state, updateHash = true) {
 
             currentSidebarState = state;
             if (updateHash && currentlyLoadedMapId) {
-            // --- FIX: Update history with search params and new hash ---
+            // Update history with search params and new hash
             const newHash = generateHash(currentlyLoadedMapId, state);
             const currentSearch = window.location.search;
             const newUrl = buildAppUrlWithHash(newHash, currentSearch);


### PR DESCRIPTION
The comment `// --- FIX: Update history with search params and new hash ---` incorrectly flagged an already implemented fix as an actionable TODO item. Modified the comment to properly document the code block.

---
*PR created automatically by Jules for task [15704252993984450356](https://jules.google.com/task/15704252993984450356) started by @jaxsnjohnson*