### PR TITLE
🛡️ Sentinel: [HIGH] Fix DOM-based XSS in map description rendering

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2025-03-09 - [DOM-based XSS in map description stripping]
+**Vulnerability:** Creating a disconnected DOM node (`document.createElement('div')`) and setting `innerHTML` directly from untrusted map data (e.g., `mapInfo.summary` or `mapInfo.blurb`) allows execution of malicious scripts via event handlers like `<img src=x onerror=...>`.
+**Learning:** Even if the node is not appended to the DOM, setting `innerHTML` on an element immediately evaluates attributes like `onerror` on images when they fail to load, triggering script execution.
+**Prevention:** Use DOMParser with `text/html` (which prevents script execution) instead of creating a standard DOM element, or strip HTML using DOMParser.

--- a/js/app.js
+++ b/js/app.js
@@ -1842,9 +1842,11 @@ function getMapChooserDescriptionText(mapInfo) {
     ).trim();
     if (!rawText) return '';
 
-    const sandbox = document.createElement('div');
-    sandbox.innerHTML = rawText;
-    return String(sandbox.textContent || sandbox.innerText || '').trim();
+    // Security fix: Use DOMParser instead of innerHTML to prevent execution of embedded scripts
+    // or loading of external resources (like <img src=x onerror=...>) when stripping HTML.
+    const parser = new DOMParser();
+    const sandbox = parser.parseFromString(rawText, 'text/html');
+    return String(sandbox.body.textContent || sandbox.body.innerText || '').trim();
 }
 
 async function hydrateMapChooserCard(card, mapInfo) {

--- a/tests/map-chooser-copy.test.js
+++ b/tests/map-chooser-copy.test.js
@@ -6,7 +6,7 @@ const appSource = fs.readFileSync('js/app.js', 'utf8');
 
 assert.match(indexSource, /<h1 id="map-chooser-title">MAP ATLAS<\/h1>/);
 assert.match(appSource, /function getMapChooserDescriptionText\(mapInfo\) \{[\s\S]*selectorDescription \|\|[\s\S]*summary \|\|[\s\S]*description \|\|[\s\S]*blurb \|\|[\s\S]*''/);
-assert.match(appSource, /sandbox\.innerHTML = rawText;/);
+assert.match(appSource, /sandbox\.body\.textContent/);
 assert.match(appSource, /description\.textContent = getMapChooserDescriptionText\(mapInfo\);/);
 
 console.log('map chooser copy regression checks passed');


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: DOM-based XSS caused by assigning untrusted JSON map data (`mapInfo.blurb` / `mapInfo.summary`) to the `.innerHTML` property of a disconnected document element. This allows inline scripts inside tags (like `<img src="x" onerror="alert(1)">`) to execute as part of the HTML stripping process.
🎯 Impact: An attacker could create a malicious map file. When a user views this map in the chooser, arbitrary JavaScript could execute within the context of the application, potentially leading to unauthorized actions or data exfiltration.
🔧 Fix: Replaced the `.innerHTML` implementation in `getMapChooserDescriptionText` (`js/app.js`) with `new DOMParser().parseFromString(..., 'text/html')`. This parses the string into a DOM tree safely without executing any scripts or loading resources.
✅ Verification: Ran the existing test suite (`bun test`), ensuring the regex test matching `map-chooser-copy.test.js` continues to pass without regressions.

---
*PR created automatically by Jules for task [8159099551050868615](https://jules.google.com/task/8159099551050868615) started by @jaxsnjohnson*