### PR TITLE
🧹 refactor: extract sidebar item creation from populateSidebar

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -5143,177 +5143,186 @@ function getMapPresetGroupLabel(item) {
     return String(item?.group || item?.category || '').trim();
 }
 
+function createSidebarFolderItem(item) {
+    const listItem = document.createElement('li');
+    listItem.classList.add('folder', 'closed');
+    const header = document.createElement('div');
+    header.classList.add('folder-header');
+    const folderName = item.name || 'Unnamed Folder!';
+    const hasChildren = Array.isArray(item.children) && item.children.length > 0;
+    const isComingSoon = item.status === 'coming-soon';
+    const isLoadable = isRenderableMapEntry(item);
+
+    const toggleBtn = document.createElement('button');
+    toggleBtn.type = 'button';
+    toggleBtn.className = 'folder-toggle-btn';
+    toggleBtn.setAttribute('aria-label', `Toggle folder: ${folderName}`);
+    toggleBtn.innerHTML = `
+        <span class="sidebar-chevron-icon" aria-hidden="true">
+            <i class="ui-icon" data-lucide="chevron-right"></i>
+        </span>
+    `;
+    if (!hasChildren) {
+        toggleBtn.disabled = true;
+        toggleBtn.setAttribute('aria-hidden', 'true');
+        toggleBtn.tabIndex = -1;
+    }
+
+    const mainAction = document.createElement('button');
+    mainAction.type = 'button';
+    mainAction.className = 'folder-main-action';
+    if (isLoadable) {
+        const loadIcon = document.createElement('span');
+        loadIcon.className = 'folder-load-icon';
+        loadIcon.setAttribute('aria-hidden', 'true');
+        loadIcon.innerHTML = `<i class="ui-icon" data-lucide="map-pin"></i>`;
+        mainAction.appendChild(loadIcon);
+    }
+    const mainActionLabel = document.createElement('span');
+    mainActionLabel.className = 'folder-main-action-label';
+    mainActionLabel.textContent = `${folderName}${isComingSoon ? ' (Soon)' : ''}`;
+    mainAction.appendChild(mainActionLabel);
+
+    const nestedList = document.createElement('ul');
+    nestedList.classList.add('nested-list');
+
+    if (hasChildren) {
+        populateSidebar(nestedList, item.children);
+    }
+
+    const toggleFolderOpen = (e) => {
+        e.stopPropagation();
+        if (!hasChildren) return;
+        listItem.classList.toggle('closed');
+        syncFolderExpandedAria(listItem);
+    };
+
+    toggleBtn.addEventListener('click', toggleFolderOpen);
+    toggleBtn.addEventListener('keydown', (e) => {
+        if (e.key === 'Enter' || e.key === ' ') {
+            e.preventDefault();
+            toggleFolderOpen(e);
+        }
+    });
+
+    if (isLoadable) {
+        header.dataset.mapId = item.id;
+        mainAction.title = `Load map: ${folderName}`;
+        mainAction.setAttribute('aria-label', `Load map: ${folderName}`);
+        mainAction.addEventListener('click', (e) => {
+            e.stopPropagation();
+            if (!isMobileLayoutActive) {
+                unlockAdvancedControls('map_selected');
+            }
+            navigateToMap(item.id);
+        });
+        mainAction.addEventListener('keydown', (e) => {
+            if (e.key === 'Enter' || e.key === ' ') {
+                e.preventDefault();
+                mainAction.click();
+            }
+        });
+    } else if (isComingSoon) {
+        header.classList.add('coming-soon');
+        mainAction.title = `${folderName} - Coming Soon!`;
+        mainAction.setAttribute('aria-label', `${folderName} coming soon`);
+        mainAction.addEventListener('click', (e) => {
+            e.stopPropagation();
+            alert(`The map "${folderName}" is coming soon!`);
+        });
+        mainAction.addEventListener('keydown', (e) => {
+            if (e.key === 'Enter' || e.key === ' ') {
+                e.preventDefault();
+                mainAction.click();
+            }
+        });
+    } else {
+        mainAction.title = `Toggle folder: ${folderName}`;
+        mainAction.setAttribute('aria-label', `Toggle folder: ${folderName}`);
+        mainAction.addEventListener('click', toggleFolderOpen);
+        mainAction.addEventListener('keydown', (e) => {
+            if (e.key === 'Enter' || e.key === ' ') {
+                e.preventDefault();
+                toggleFolderOpen(e);
+            }
+        });
+    }
+    syncFolderExpandedAria(listItem);
+    header.appendChild(toggleBtn);
+    header.appendChild(mainAction);
+    listItem.appendChild(header);
+    listItem.appendChild(nestedList);
+
+    return listItem;
+}
+
+function createSidebarMapItem(item) {
+    const listItem = document.createElement('li');
+    listItem.classList.add('map-item');
+    listItem.textContent = item.name || 'Unnamed Map!'; // Add fallback text
+    listItem.dataset.mapId = item.id;
+    listItem.tabIndex = 0;
+    listItem.setAttribute('role', 'button');
+
+    if (item.status === 'coming-soon') {
+        listItem.classList.add('coming-soon');
+        listItem.textContent = `${item.name || 'Unnamed Map!'} (Soon)`;
+        listItem.title = `${item.name || 'Coming Soon!'} - Coming Soon!`;
+        listItem.addEventListener('click', (e) => {
+            e.stopPropagation();
+            alert(`The map "${item.name || 'this map'}" is coming soon!`);
+        });
+        listItem.addEventListener('keydown', (e) => {
+            if (e.key === 'Enter' || e.key === ' ') {
+                e.preventDefault();
+                listItem.click();
+            }
+        });
+    } else if (!isRenderableMapEntry(item)) {
+        listItem.classList.add('coming-soon');
+        listItem.textContent = `${item.name || 'Unnamed Map!'} (Unavailable)`;
+        listItem.title = `${item.name || 'This map'} is not currently available`;
+        listItem.addEventListener('click', (e) => {
+            e.stopPropagation();
+            alert(`The map "${item.name || 'this map'}" is not currently available.`);
+        });
+        listItem.addEventListener('keydown', (e) => {
+            if (e.key === 'Enter' || e.key === ' ') {
+                e.preventDefault();
+                listItem.click();
+            }
+        });
+    } else {
+        listItem.title = `Load map: ${item.name || 'Unnamed Map!'}`;
+        listItem.addEventListener('click', (e) => {
+            e.stopPropagation();
+            if (!isMobileLayoutActive) {
+                unlockAdvancedControls('map_selected');
+            }
+            navigateToMap(item.id);
+        });
+        listItem.addEventListener('keydown', (e) => {
+            if (e.key === 'Enter' || e.key === ' ') {
+                e.preventDefault();
+                listItem.click();
+            }
+        });
+    }
+    return listItem;
+}
+
+function createSidebarListItem(item) {
+    if (item.type === 'folder') {
+        return createSidebarFolderItem(item);
+    } else {
+        return createSidebarMapItem(item);
+    }
+}
+
 function populateSidebar(parentElement, items) {
     parentElement.innerHTML = '';
     const sourceItems = Array.isArray(items) ? items : [];
     const hasGroupedItems = sourceItems.some((item) => getMapPresetGroupLabel(item));
-
-    function createSidebarListItem(item) {
-        const listItem = document.createElement('li');
-
-        if (item.type === 'folder') {
-            listItem.classList.add('folder', 'closed');
-            const header = document.createElement('div');
-            header.classList.add('folder-header');
-            const folderName = item.name || 'Unnamed Folder!';
-            const hasChildren = Array.isArray(item.children) && item.children.length > 0;
-            const isComingSoon = item.status === 'coming-soon';
-            const isLoadable = isRenderableMapEntry(item);
-
-            const toggleBtn = document.createElement('button');
-            toggleBtn.type = 'button';
-            toggleBtn.className = 'folder-toggle-btn';
-            toggleBtn.setAttribute('aria-label', `Toggle folder: ${folderName}`);
-            toggleBtn.innerHTML = `
-                <span class="sidebar-chevron-icon" aria-hidden="true">
-                    <i class="ui-icon" data-lucide="chevron-right"></i>
-                </span>
-            `;
-            if (!hasChildren) {
-                toggleBtn.disabled = true;
-                toggleBtn.setAttribute('aria-hidden', 'true');
-                toggleBtn.tabIndex = -1;
-            }
-
-            const mainAction = document.createElement('button');
-            mainAction.type = 'button';
-            mainAction.className = 'folder-main-action';
-            if (isLoadable) {
-                const loadIcon = document.createElement('span');
-                loadIcon.className = 'folder-load-icon';
-                loadIcon.setAttribute('aria-hidden', 'true');
-                loadIcon.innerHTML = `<i class="ui-icon" data-lucide="map-pin"></i>`;
-                mainAction.appendChild(loadIcon);
-            }
-            const mainActionLabel = document.createElement('span');
-            mainActionLabel.className = 'folder-main-action-label';
-            mainActionLabel.textContent = `${folderName}${isComingSoon ? ' (Soon)' : ''}`;
-            mainAction.appendChild(mainActionLabel);
-
-            const nestedList = document.createElement('ul');
-            nestedList.classList.add('nested-list');
-
-            if (hasChildren) {
-                populateSidebar(nestedList, item.children);
-            }
-
-            const toggleFolderOpen = (e) => {
-                e.stopPropagation();
-                if (!hasChildren) return;
-                listItem.classList.toggle('closed');
-                syncFolderExpandedAria(listItem);
-            };
-
-            toggleBtn.addEventListener('click', toggleFolderOpen);
-            toggleBtn.addEventListener('keydown', (e) => {
-                if (e.key === 'Enter' || e.key === ' ') {
-                    e.preventDefault();
-                    toggleFolderOpen(e);
-                }
-            });
-
-            if (isLoadable) {
-                header.dataset.mapId = item.id;
-                mainAction.title = `Load map: ${folderName}`;
-                mainAction.setAttribute('aria-label', `Load map: ${folderName}`);
-                mainAction.addEventListener('click', (e) => {
-                    e.stopPropagation();
-                    if (!isMobileLayoutActive) {
-                        unlockAdvancedControls('map_selected');
-                    }
-                    navigateToMap(item.id);
-                });
-                mainAction.addEventListener('keydown', (e) => {
-                    if (e.key === 'Enter' || e.key === ' ') {
-                        e.preventDefault();
-                        mainAction.click();
-                    }
-                });
-            } else if (isComingSoon) {
-                header.classList.add('coming-soon');
-                mainAction.title = `${folderName} - Coming Soon!`;
-                mainAction.setAttribute('aria-label', `${folderName} coming soon`);
-                mainAction.addEventListener('click', (e) => {
-                    e.stopPropagation();
-                    alert(`The map "${folderName}" is coming soon!`);
-                });
-                mainAction.addEventListener('keydown', (e) => {
-                    if (e.key === 'Enter' || e.key === ' ') {
-                        e.preventDefault();
-                        mainAction.click();
-                    }
-                });
-            } else {
-                mainAction.title = `Toggle folder: ${folderName}`;
-                mainAction.setAttribute('aria-label', `Toggle folder: ${folderName}`);
-                mainAction.addEventListener('click', toggleFolderOpen);
-                mainAction.addEventListener('keydown', (e) => {
-                    if (e.key === 'Enter' || e.key === ' ') {
-                        e.preventDefault();
-                        toggleFolderOpen(e);
-                    }
-                });
-            }
-            syncFolderExpandedAria(listItem);
-            header.appendChild(toggleBtn);
-            header.appendChild(mainAction);
-            listItem.appendChild(header);
-            listItem.appendChild(nestedList);
-
-        } else { // Map Item
-            listItem.classList.add('map-item');
-            listItem.textContent = item.name || 'Unnamed Map!'; // Add fallback text
-            listItem.dataset.mapId = item.id;
-            listItem.tabIndex = 0;
-            listItem.setAttribute('role', 'button');
-
-            if (item.status === 'coming-soon') {
-                listItem.classList.add('coming-soon');
-                listItem.textContent = `${item.name || 'Unnamed Map!'} (Soon)`;
-                listItem.title = `${item.name || 'Coming Soon!'} - Coming Soon!`;
-                listItem.addEventListener('click', (e) => {
-                    e.stopPropagation();
-                    alert(`The map "${item.name || 'this map'}" is coming soon!`);
-                });
-                listItem.addEventListener('keydown', (e) => {
-                    if (e.key === 'Enter' || e.key === ' ') {
-                        e.preventDefault();
-                        listItem.click();
-                    }
-                });
-            } else if (!isRenderableMapEntry(item)) {
-                listItem.classList.add('coming-soon');
-                listItem.textContent = `${item.name || 'Unnamed Map!'} (Unavailable)`;
-                listItem.title = `${item.name || 'This map'} is not currently available`;
-                listItem.addEventListener('click', (e) => {
-                    e.stopPropagation();
-                    alert(`The map "${item.name || 'this map'}" is not currently available.`);
-                });
-                listItem.addEventListener('keydown', (e) => {
-                    if (e.key === 'Enter' || e.key === ' ') {
-                        e.preventDefault();
-                        listItem.click();
-                    }
-                });
-            } else {
-                listItem.title = `Load map: ${item.name || 'Unnamed Map!'}`;
-                listItem.addEventListener('click', (e) => {
-                    e.stopPropagation();
-                    if (!isMobileLayoutActive) {
-                        unlockAdvancedControls('map_selected');
-                    }
-                    navigateToMap(item.id);
-                });
-                listItem.addEventListener('keydown', (e) => {
-                    if (e.key === 'Enter' || e.key === ' ') {
-                        e.preventDefault();
-                        listItem.click();
-                    }
-                });
-            }
-        }
-        return listItem;
-    }
 
     if (!hasGroupedItems) {
         sourceItems.forEach((item) => {


### PR DESCRIPTION
🎯 **What:** Extracted the logic inside the lengthy `populateSidebar` function in `js/app.js` into modular helper functions: `createSidebarFolderItem`, `createSidebarMapItem`, and `createSidebarListItem`.

💡 **Why:** The original `populateSidebar` function was overly long and complex, handling multiple distinct responsibilities (looping over arrays, grouping presets, building DOM for folders, building DOM for map items, attaching event listeners). Breaking this into smaller functions improves maintainability, readability, and isolates the item creation concerns.

✅ **Verification:** 
- Used a script to automatically patch the file, ensuring syntax validity.
- Ran `git diff` manually to confirm that the existing logic and variable access was completely preserved.
- Executed `bun test tests/` resulting in 0 regressions across the codebase.

✨ **Result:** `populateSidebar` is now concise, delegating to helper functions that handle the nitty-gritty DOM element building separately, greatly improving code health without changing functionality.

---
*PR created automatically by Jules for task [9884722540657487610](https://jules.google.com/task/9884722540657487610) started by @jaxsnjohnson*