### PR TITLE
🧹 [Code Health] Consolidate duplicate HTML sanitization functions

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -274,7 +274,7 @@ function formatPropertiesForPopup(properties, hasFollowingDescription) {
     return html;
 }
 
-function sanitizeTextForHtml(value) {
+function escapeHtml(value) {
     return String(value || '')
         .replace(/&/g, '&amp;')
         .replace(/</g, '&lt;')
@@ -333,11 +333,11 @@ function resolveLinkedMapData(featureData) {
 }
 
 function createPoiTooltipContent(data) {
-    const safeName = sanitizeTextForHtml(data?.name || 'Unnamed Location');
+    const safeName = escapeHtml(data?.name || 'Unnamed Location');
     const rawType = String(data?.type || '').trim();
     if (!rawType) return safeName;
 
-    return `${safeName} <span class="poi-hover-tooltip-separator">•</span> ${sanitizeTextForHtml(rawType)}`;
+    return `${safeName} <span class="poi-hover-tooltip-separator">•</span> ${escapeHtml(rawType)}`;
 }
 
 function getPoiTooltipOptions() {
@@ -475,14 +475,14 @@ function applySearchParamsToCurrentMap(params = new URLSearchParams(window.locat
 
 // --- NEW: Unified Popup Content Generator ---
 function createPopupContent(data, type) {
-    const safePronunciation = data.pronunciation ? sanitizeTextForHtml(data.pronunciation) : '';
-    const safeSummary = data.summary ? sanitizeTextForHtml(data.summary) : '';
-    const safeDescription = data.description ? sanitizeTextForHtml(data.description) : '';
+    const safePronunciation = data.pronunciation ? escapeHtml(data.pronunciation) : '';
+    const safeSummary = data.summary ? escapeHtml(data.summary) : '';
+    const safeDescription = data.description ? escapeHtml(data.description) : '';
 
     // Part 1: Build the header, which is always visible.
     let headerHtml = '';
     if (data.name) {
-        const safeName = sanitizeTextForHtml(data.name);
+        const safeName = escapeHtml(data.name);
         const escapedName = escapeForSingleQuotedAttribute(data.name);
         const safeWikiHref = sanitizeWikiLinkForHref(data.wikiLink);
         let shareButtonHtml = '';
@@ -504,7 +504,7 @@ function createPopupContent(data, type) {
     const linkedMap = resolveLinkedMapData(data);
     if (linkedMap) {
         const escapedLinkedMapId = escapeForSingleQuotedAttribute(linkedMap.id);
-        const linkedMapName = sanitizeTextForHtml(linkedMap.name);
+        const linkedMapName = escapeHtml(linkedMap.name);
         const mapJumpIcon = `<i class="ui-icon" data-lucide="map" aria-hidden="true"></i>`;
         headerHtml += `<div class="popup-map-jump"><a href="#" onclick="return openLinkedMapFromPopup(event, '${escapedLinkedMapId}')" title="Open map: ${linkedMapName}">${mapJumpIcon}<span>Open ${linkedMapName} map</span></a></div>`;
     }
@@ -2532,15 +2532,6 @@ function computeSearchMatch(term, primaryText, secondaryText = '') {
     }
 
     return { matched: false, score: -1, matchedByContent: false };
-}
-
-function escapeHtml(value) {
-    return String(value || '')
-        .replace(/&/g, '&amp;')
-        .replace(/</g, '&lt;')
-        .replace(/>/g, '&gt;')
-        .replace(/"/g, '&quot;')
-        .replace(/'/g, '&#39;');
 }
 
 function highlightSearchText(text, term) {

--- a/tests/createPoiTooltipContent.test.js
+++ b/tests/createPoiTooltipContent.test.js
@@ -2,7 +2,7 @@ const assert = require('node:assert/strict');
 const fs = require('node:fs');
 
 const appSource = fs.readFileSync('js/app.js', 'utf8');
-const sanitizeStart = appSource.indexOf('function sanitizeTextForHtml(value) {');
+const sanitizeStart = appSource.indexOf('function escapeHtml(value) {');
 const escapeStart = appSource.indexOf('function escapeForSingleQuotedAttribute(value) {');
 const tooltipStart = appSource.indexOf('function createPoiTooltipContent(data) {');
 const tooltipOptionsStart = appSource.indexOf('function getPoiTooltipOptions() {');

--- a/tests/createPopupContent.test.js
+++ b/tests/createPopupContent.test.js
@@ -3,7 +3,7 @@ const fs = require('node:fs');
 
 const appSource = fs.readFileSync('js/app.js', 'utf8');
 const formatStart = appSource.indexOf('function formatPropertiesForPopup(properties, hasFollowingDescription) {');
-const sanitizeStart = appSource.indexOf('function sanitizeTextForHtml(value) {');
+const sanitizeStart = appSource.indexOf('function escapeHtml(value) {');
 const escapeStart = appSource.indexOf('function escapeForSingleQuotedAttribute(value) {');
 const wikiLinkStart = appSource.indexOf('function sanitizeWikiLinkForHref(value) {');
 const resolveStart = appSource.indexOf('function resolveLinkedMapData(featureData) {');

--- a/tests/formatPropertiesForPopup.test.js
+++ b/tests/formatPropertiesForPopup.test.js
@@ -3,7 +3,7 @@ const fs = require('node:fs');
 
 const appSource = fs.readFileSync('js/app.js', 'utf8');
 const fnStart = appSource.indexOf('function formatPropertiesForPopup(properties, hasFollowingDescription) {');
-const fnEnd = appSource.indexOf('function sanitizeTextForHtml(value) {');
+const fnEnd = appSource.indexOf('function escapeHtml(value) {');
 
 if (fnStart === -1 || fnEnd === -1 || fnEnd <= fnStart) {
     throw new Error('Could not locate formatPropertiesForPopup function in js/app.js');


### PR DESCRIPTION
🎯 **What:** Removed duplicate code logic for HTML sanitization (`sanitizeTextForHtml` and `escapeHtml`) in `js/app.js`. Consolidated on the name `escapeHtml`.
💡 **Why:** Having multiple functions that do the exact same thing (escaping `&`, `<`, `>`, `"`, `'`) leads to confusion and potential future maintenance headaches if one function is updated but not the other.
✅ **Verification:** Updated test slice boundaries to refer to `escapeHtml` and successfully ran `bun test` across 50 files with 0 failures. Also verified no regressions on the code review step.
✨ **Result:** Improved maintainability by DRY-ing up the codebase without introducing regressions.

---
*PR created automatically by Jules for task [13673615263651312908](https://jules.google.com/task/13673615263651312908) started by @jaxsnjohnson*