### PR TITLE
🔒 Fix Stored XSS in Map Blurb Rendering

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,7 @@
 **Vulnerability:** Creating a disconnected DOM node (`document.createElement('div')`) and setting `innerHTML` directly from untrusted map data (e.g., `mapInfo.summary` or `mapInfo.blurb`) allows execution of malicious scripts via event handlers like `<img src=x onerror=...>`.
 **Learning:** Even if the node is not appended to the DOM, setting `innerHTML` on an element immediately evaluates attributes like `onerror` on images when they fail to load, triggering script execution.
 **Prevention:** Use DOMParser with `text/html` (which prevents script execution) instead of creating a standard DOM element, or strip HTML using DOMParser.
+## 2025-03-09 - [Stored XSS in Map Blurb Rendering]
+**Vulnerability:** Setting `innerHTML` directly from untrusted map data (`mapInfo.blurb`) without sanitization allowed arbitrary HTML and malicious scripts to be executed, resulting in a Stored XSS vulnerability.
+**Learning:** Even intentionally formatted HTML data from external configurations or definitions must be sanitized before being injected into the DOM via `innerHTML` or template literals.
+**Prevention:** Use a mature sanitization library like `DOMPurify.sanitize()` when inserting rich text or formatted HTML that originates from user or external file input into the DOM to strip dangerous event handlers and script tags while preserving safe markup.

--- a/index.html
+++ b/index.html
@@ -428,6 +428,7 @@
         integrity="sha256-20nQCchB9co0qIjJZRGuk2/Z9VM+kNiyxNV1lvTlZBo="
         crossorigin=""></script>
     <script src="https://unpkg.com/lucide@latest"></script>
+    <script src="https://unpkg.com/dompurify@3.1.7/dist/purify.min.js"></script>
 
     <script>
         (function loadVersionedLocalScripts() {

--- a/js/app.js
+++ b/js/app.js
@@ -1442,7 +1442,13 @@ function renderMapBlurbContent(mapInfo = getMapRuntimeData(currentlyLoadedMapId)
     if (!mapBlurbElement) return;
     const safeName = escapeHtml(mapInfo?.name || 'Atlas');
     const defaultCopy = '<p>Open the guide for controls, shortcuts, and atlas help.</p>';
-    const blurbBody = mapInfo?.blurb || defaultCopy;
+
+    // Security Fix: Sanitize HTML content containing map blurbs before inserting it into the DOM
+    // to prevent Stored XSS via malicious injected tags or event handlers.
+    // If DOMPurify fails to load, we fail closed by escaping the HTML to prevent XSS.
+    const blurbBody = typeof DOMPurify !== 'undefined'
+        ? DOMPurify.sanitize(mapInfo?.blurb || defaultCopy)
+        : escapeHtml(mapInfo?.blurb || defaultCopy);
 
     if (isMobileLayoutActive) {
         mapBlurbElement.innerHTML = `
@@ -1458,7 +1464,11 @@ function renderMapBlurbContent(mapInfo = getMapRuntimeData(currentlyLoadedMapId)
         return;
     }
 
-    mapBlurbElement.innerHTML = mapInfo?.blurb || '';
+    const desktopBlurb = typeof DOMPurify !== 'undefined'
+        ? DOMPurify.sanitize(mapInfo?.blurb || '')
+        : escapeHtml(mapInfo?.blurb || '');
+
+    mapBlurbElement.innerHTML = desktopBlurb;
 }
 
 function getMobileMapListEntryCount() {

--- a/tests/renderMapBlurbContent.test.js
+++ b/tests/renderMapBlurbContent.test.js
@@ -1,0 +1,103 @@
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+
+// Mock DOMPurify as it would be globally available from the CDN script
+global.DOMPurify = {
+    sanitize: (html) => {
+        if (!html) return html;
+        // Super simple mock of DOMPurify for the test
+        return html.replace(/<img[^>]+onerror[^>]+>/g, '').replace(/<script.*?>.*?<\/script>/g, '');
+    }
+};
+
+const appSource = fs.readFileSync('js/app.js', 'utf8');
+
+const escapeHtmlStart = appSource.indexOf('function escapeHtml(value) {');
+const escapeHtmlEnd = appSource.indexOf('function escapeForSingleQuotedAttribute(value) {');
+const renderStart = appSource.indexOf('function renderMapBlurbContent');
+const renderEnd = appSource.indexOf('function getMobileMapListEntryCount');
+
+if (escapeHtmlStart === -1 || escapeHtmlEnd === -1 || renderStart === -1 || renderEnd === -1) {
+    throw new Error('Could not locate required functions in js/app.js');
+}
+
+const escapeHtmlSource = appSource.slice(escapeHtmlStart, escapeHtmlEnd);
+const renderSource = appSource.slice(renderStart, renderEnd);
+
+// Set up globals needed by the function
+global.mapBlurbElement = {
+    innerHTML: ''
+};
+global.isMobileLayoutActive = false;
+
+// We do not need currentlyLoadedMapId or getMapRuntimeData to be real since we pass mapInfo directly
+global.currentlyLoadedMapId = 'test';
+global.getMapRuntimeData = () => ({});
+
+// eslint-disable-next-line no-eval
+eval(escapeHtmlSource);
+// eslint-disable-next-line no-eval
+eval(renderSource);
+
+// Test safe HTML
+renderMapBlurbContent({
+    name: 'Test Map',
+    blurb: '<p>This is a <strong>safe</strong> blurb with <a href="#">a link</a>.</p>'
+});
+
+assert.equal(
+    global.mapBlurbElement.innerHTML,
+    '<p>This is a <strong>safe</strong> blurb with <a href="#">a link</a>.</p>',
+    'Safe HTML should be preserved'
+);
+
+// Test dangerous HTML
+renderMapBlurbContent({
+    name: 'Danger Map',
+    blurb: '<p>Malicious code</p><img src=x onerror=alert(1)>'
+});
+
+assert.equal(
+    global.mapBlurbElement.innerHTML.includes('onerror'),
+    false,
+    'Malicious onerror attribute should be sanitized'
+);
+
+// Test mobile layout
+global.isMobileLayoutActive = true;
+renderMapBlurbContent({
+    name: 'Mobile Map',
+    blurb: '<p>Mobile test</p><script>alert("xss")</script>'
+});
+
+assert.equal(
+    global.mapBlurbElement.innerHTML.includes('<script>'),
+    false,
+    'Mobile blurb template should sanitize blurbBody'
+);
+assert.equal(
+    global.mapBlurbElement.innerHTML.includes('Mobile test'),
+    true,
+    'Mobile blurb template should include safe text'
+);
+
+// Test fail closed when DOMPurify is missing
+const originalDOMPurify = global.DOMPurify;
+global.DOMPurify = undefined;
+global.isMobileLayoutActive = false;
+
+renderMapBlurbContent({
+    name: 'No Purify Map',
+    blurb: '<p>Dangerous <img></p>'
+});
+
+assert.equal(
+    global.mapBlurbElement.innerHTML,
+    '&lt;p&gt;Dangerous &lt;img&gt;&lt;/p&gt;',
+    'Should escape HTML when DOMPurify is undefined'
+);
+
+// Restore for completion check
+global.DOMPurify = originalDOMPurify;
+
+console.log('renderMapBlurbContent sanitization tests passed');


### PR DESCRIPTION
🎯 **What:** The vulnerability fixed
Stored XSS in the map blurb rendering (`renderMapBlurbContent`) where untrusted map definition strings containing HTML were directly assigned to `innerHTML`.
    
⚠️ **Risk:** The potential impact if left unfixed
Malicious map JSON files could inject arbitrary `<script>` tags or elements with inline event handlers (like `<img onerror>`). This would cause the JavaScript payload to execute in the user's browser whenever they view the map blurb, leading to session hijacking, defacement, or further client-side attacks.

🛡️ **Solution:** How the fix addresses the vulnerability
Added DOMPurify via unpkg CDN to `index.html`. Updated `renderMapBlurbContent` in `js/app.js` to pass `mapInfo.blurb` through `DOMPurify.sanitize()` before injecting it into the DOM. This safely strips scripts and event handlers while preserving intended formatting tags (like `<p>` and `<a>`). Implemented a "fail closed" fallback: if the DOMPurify CDN fails to load, it falls back to strict `escapeHtml()` instead of rendering raw markup.

---
*PR created automatically by Jules for task [15590932520523529884](https://jules.google.com/task/15590932520523529884) started by @jaxsnjohnson*