### PR TITLE
🧪 test: improve unit tests for getMapBackgroundColor

### DIFF
--- a/tests/getMapBackgroundColor.test.js
+++ b/tests/getMapBackgroundColor.test.js
@@ -69,4 +69,16 @@ global.currentEffectiveTheme = 'dark';
 result = getMapBackgroundColor({});
 assert.equal(result, '#customDark');
 
+// Test 8: returns default colors when getConfigValue is undefined
+global.getConfigValue = undefined;
+eval(fnSource); // Re-evaluate so configuredMapBackgroundColors falls back to DEFAULT_MAP_BACKGROUND_COLORS
+
+global.currentEffectiveTheme = 'light';
+result = getMapBackgroundColor(null);
+assert.equal(result, '#f4f0eb'); // DEFAULT_MAP_BACKGROUND_COLORS.light
+
+global.currentEffectiveTheme = 'dark';
+result = getMapBackgroundColor(null);
+assert.equal(result, '#050510'); // DEFAULT_MAP_BACKGROUND_COLORS.dark
+
 console.log('getMapBackgroundColor tests passed');


### PR DESCRIPTION
🎯 What: Added tests for the edge cases for `getMapBackgroundColor` where `getConfigValue` is not defined.
📊 Coverage: We now cover situations when `typeof getConfigValue === 'function'` is false and fallback variables are used.
✨ Result: Improved unit test coverage for the previously untested branches, improving overall reliability.

---
*PR created automatically by Jules for task [9950960177722600812](https://jules.google.com/task/9950960177722600812) started by @jaxsnjohnson*