### PR TITLE
⚡ Bolt: Skip unnecessary filter/search operations

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -33,3 +33,6 @@
 ## 2024-05-03 - Optimize redundant string interpolation in rendering loops
 **Learning:** Found loops for `addRegionsToMap` and `addRoadsToMap` interpolating properties and variables into a `let popupContent = ""` local variable, which was never actually used since the code fell back to a shared helper `createPopupContent` just below. This dead code was evaluated multiple times at map init and feature render time.
 **Action:** Always verify if a manually generated string layout in a tight loop is actually utilized. Dead interpolations (especially invoking string helpers) can be entirely refactored away to reduce object allocation.
+## 2024-05-29 - Bypassing DOM Operations During Search Inactive States
+**Learning:** Functions like `searchMapRegions` and `searchMapLines` were unnecessarily executing DOM queries (`querySelectorAll`) and building filter sets even when search was inactive for the current map, just because they were called from the main filter loop.
+**Action:** In search sub-routines that are part of a larger filter/render loop, always apply an immediate early return (e.g., `if (!searchActive) return;`) at the very top of the function if its only purpose is to populate search results. This prevents evaluating expensive DOM and layer-iteration logic.

--- a/js/app.js
+++ b/js/app.js
@@ -3355,8 +3355,8 @@ function searchMapMarkers(searchTerm, results, allPoiGroupsChecked, activeSpecif
         const poiGroup = getPoiGroup(poi.type);
         const groupMatch = allPoiGroupsChecked || activeSpecificGroupFilters.has(poiGroup);
         let match = { matched: false, score: -1, matchedByContent: false };
-        // ⚡ Bolt: Skip expensive string concatenation and fuzzy matching when the user is only filtering (search is empty).
-        if (searchFiltersCurrentMap) {
+        // ⚡ Bolt: Skip expensive string concatenation and fuzzy matching when the user is only filtering (search is empty) or the marker is filtered out.
+        if (searchFiltersCurrentMap && groupMatch) {
             match = computeSearchMatch(searchTerm, poi.name, `${poi.summary || ''} ${poi.description || ''}`);
         }
         const isSearchMatch = !searchTerm || match.matched;
@@ -3384,14 +3384,15 @@ function searchMapMarkers(searchTerm, results, allPoiGroupsChecked, activeSpecif
 }
 
 function searchMapRegions(searchTerm, results, searchFiltersCurrentMap) {
+    if (!searchFiltersCurrentMap || !currentRegionGroup) return;
+
     const activeRegionTypeFilters = new Set();
     poiFilterContainer.querySelectorAll('.region-type-filter:checked').forEach((checkbox) => {
         activeRegionTypeFilters.add(checkbox.value);
     });
     const allRegionTypesChecked = filterToggleAllCheckbox.checked && !filterToggleAllCheckbox.indeterminate;
 
-    if (searchFiltersCurrentMap && currentRegionGroup) {
-        currentRegionGroup.eachLayer((layer) => {
+    currentRegionGroup.eachLayer((layer) => {
             const region = layer.regionData;
             if (!region || !region.name) return;
 
@@ -3417,18 +3418,18 @@ function searchMapRegions(searchTerm, results, searchFiltersCurrentMap) {
                 }
             }
         });
-    }
 }
 
 function searchMapLines(searchTerm, results, searchFiltersCurrentMap) {
+    if (!searchFiltersCurrentMap || !currentRoadGroup) return;
+
     const activeLineTypeFilters = new Set();
     poiFilterContainer.querySelectorAll('.line-type-filter:checked').forEach((checkbox) => {
         activeLineTypeFilters.add(checkbox.value);
     });
     const allLineTypesChecked = filterToggleAllCheckbox.checked && !filterToggleAllCheckbox.indeterminate;
 
-    if (searchFiltersCurrentMap && currentRoadGroup) {
-        currentRoadGroup.eachLayer((layer) => {
+    currentRoadGroup.eachLayer((layer) => {
             const line = layer.roadData;
             if (!line) return;
             const lineName = line.name || line.type || 'Unnamed Line';
@@ -3454,7 +3455,6 @@ function searchMapLines(searchTerm, results, searchFiltersCurrentMap) {
                 }
             }
         });
-    }
 }
 
 function searchMapRoutes(searchTerm, results, searchFiltersCurrentMap) {


### PR DESCRIPTION
💡 **What:** Added early returns in region and line search functions, and added a category filter condition to skip fuzzy searching for hidden markers.
🎯 **Why:** To improve performance by bypassing expensive string concatenations, fuzzy matching, and DOM queries during the map's filter loop. Previously, the application calculated search matches for markers that were hidden by the category toggles, and queried the DOM for region/line filter checkboxes even when the search bar was empty.
📊 **Impact:** Reduces execution time of `updateVisibleMarkersAndSearch` when toggling filters, particularly on maps with many markers, regions, and lines. Avoids unnecessary O(n) DOM operations.
🔬 **Measurement:** Profile `updateVisibleMarkersAndSearch` when checking/unchecking POI filters on a map with many regions and markers. The execution time should be lower because `computeSearchMatch` and `querySelectorAll` are bypassed.

---
*PR created automatically by Jules for task [6080170412359076779](https://jules.google.com/task/6080170412359076779) started by @jaxsnjohnson*