### PR TITLE
🎨 Palette: Add ARIA labels to feature selector and search input

### DIFF
--- a/map-editor.html
+++ b/map-editor.html
@@ -164,12 +164,12 @@
                 </summary>
 
                 <div class="map-editor-feature-controls" style="display: flex; gap: 10px; margin-top: 14px; margin-bottom: 10px;">
-                    <select id="editor-feature-type-select" style="padding: 4px;">
+                    <select id="editor-feature-type-select" aria-label="Feature Type" style="padding: 4px;">
                         <option value="points">POIs</option>
                         <option value="regions">Regions</option>
                         <option value="lines">Lines</option>
                     </select>
-                    <input id="editor-feature-search" type="search" placeholder="Search features..." style="flex: 1; padding: 4px;">
+                    <input id="editor-feature-search" type="search" aria-label="Search Features" placeholder="Search features..." style="flex: 1; padding: 4px;">
                 </div>
 
                 <div id="editor-unified-feature-list" class="map-editor-feature-list"></div>


### PR DESCRIPTION
**💡 What:** Added explicit `aria-label` attributes to the `#editor-feature-type-select` and `#editor-feature-search` inputs inside the unified feature list side-panel in `map-editor.html`.

**🎯 Why:** The feature search and feature type selector dropdowns didn't have associated `<label>` tags or `aria-label` strings. This makes the elements ambiguous or confusing for screen-reader users, as they are purely visual interactions.

**♿ Accessibility:** Improves screen-reader compatibility and adherence to basic accessibility forms guidelines. Ensure all form elements have an accessible name.

---
*PR created automatically by Jules for task [14269833146722436495](https://jules.google.com/task/14269833146722436495) started by @jaxsnjohnson*