### PR TITLE
🧪 [Test Improvement] Add coverage for buildManifestTreeFromFlatEntries invalid inputs

### DIFF
--- a/tests/editor-shared.test.js
+++ b/tests/editor-shared.test.js
@@ -4,6 +4,7 @@ const {
     applyMapSettings,
     buildFeatureSelectionKey,
     buildFlatManifestEntries,
+    buildManifestTreeFromFlatEntries,
     createRepoFileBackedMapSource,
     detectLineCollectionKey,
     filterMapTree,
@@ -636,6 +637,12 @@ assert.equal(
         }),
         /Missing required file: maps\/missing-child\.webp/
     );
+
+    assert.deepEqual(buildManifestTreeFromFlatEntries(null), []);
+    assert.deepEqual(buildManifestTreeFromFlatEntries(undefined), []);
+    assert.deepEqual(buildManifestTreeFromFlatEntries({}), []);
+    assert.deepEqual(buildManifestTreeFromFlatEntries('not an array'), []);
+    assert.deepEqual(buildManifestTreeFromFlatEntries(123), []);
 
     console.log('editor shared helper regression checks passed');
 })().catch((error) => {


### PR DESCRIPTION
🎯 **What:** The testing gap addressed was testing the `buildManifestTreeFromFlatEntries` early return case when invalid inputs are provided.
📊 **Coverage:** Evaluated various edge cases for invalid inputs, covering cases where the user passes `null`, `undefined`, a primitive string, an integer, and a raw object.
✨ **Result:** Verified that passing these types accurately triggers the early return resulting in an empty array `[]`.

---
*PR created automatically by Jules for task [2899049858578237835](https://jules.google.com/task/2899049858578237835) started by @jaxsnjohnson*