### PR TITLE
🔒 Sanitize Help Modal Tab HTML to prevent DOM XSS

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -6,3 +6,7 @@
 **Vulnerability:** Setting `innerHTML` directly from untrusted map data (`mapInfo.blurb`) without sanitization allowed arbitrary HTML and malicious scripts to be executed, resulting in a Stored XSS vulnerability.
 **Learning:** Even intentionally formatted HTML data from external configurations or definitions must be sanitized before being injected into the DOM via `innerHTML` or template literals.
 **Prevention:** Use a mature sanitization library like `DOMPurify.sanitize()` when inserting rich text or formatted HTML that originates from user or external file input into the DOM to strip dangerous event handlers and script tags while preserving safe markup.
+## 2025-05-04 - Unsanitized Help Modal Tabs
+**Vulnerability:** DOM-based XSS via `tab.html` assignment directly to `innerHTML` in `hydrateHelpModal`.
+**Learning:** Configurable or injected HTML content was not passed through a sanitizer before rendering, allowing arbitrary script execution if configuration data is tampered with.
+**Prevention:** Always use `DOMPurify.sanitize()` when injecting untrusted or external HTML. Implement an inline `escapeHtml()` fallback when `DOMPurify` is conditionally loaded to ensure a "fail-closed" security posture.

--- a/js/app-config.js
+++ b/js/app-config.js
@@ -5,6 +5,15 @@
     }
     root.AppConfig = factory(root);
 }(typeof globalThis !== 'undefined' ? globalThis : this, function createAppConfig(root = {}) {
+    function escapeHtml(value) {
+        return String(value || '')
+            .replace(/&/g, '&amp;')
+            .replace(/</g, '&lt;')
+            .replace(/>/g, '&gt;')
+            .replace(/"/g, '&quot;')
+            .replace(/'/g, '&#39;');
+    }
+
     const DEFAULT_SITE_CONFIG = {
         brand: {
             siteName: 'HAG Interactive World Map Viewer',
@@ -514,7 +523,10 @@
             const content = documentRef.createElement('div');
             content.id = `tab-${id}`;
             content.className = `tab-content${index === 0 ? ' active' : ''}`;
-            content.innerHTML = tab.html || '';
+            const rawHtml = tab.html || '';
+            content.innerHTML = typeof DOMPurify !== 'undefined'
+                ? DOMPurify.sanitize(rawHtml)
+                : escapeHtml(rawHtml);
             body.appendChild(content);
         });
     }


### PR DESCRIPTION
🎯 **What:** Fixed a DOM-based XSS vulnerability in `hydrateHelpModal` inside `js/app-config.js`.

⚠️ **Risk:** The `tab.html` value from the configuration was directly assigned to `content.innerHTML` without sanitization. If the site configuration is dynamically generated, overridden, or compromised, malicious HTML/scripts could be injected and executed in the context of the map viewer.

🛡️ **Solution:** The fix integrates `DOMPurify` (already used elsewhere in the application) to sanitize the HTML before injection. An inline `escapeHtml()` function was also added to act as a fail-closed fallback if `DOMPurify` fails to load.

---
*PR created automatically by Jules for task [17841962225772103998](https://jules.google.com/task/17841962225772103998) started by @jaxsnjohnson*