### PR TITLE
docs: Update DOMParser comment to use descriptive language

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -1859,7 +1859,7 @@ function getMapChooserDescriptionText(mapInfo) {
     ).trim();
     if (!rawText) return '';
 
-    // Security fix: Use DOMParser instead of innerHTML to prevent execution of embedded scripts
+    // Security fix: Uses DOMParser instead of innerHTML to prevent execution of embedded scripts
     // or loading of external resources (like <img src=x onerror=...>) when stripping HTML.
     const parser = new DOMParser();
     const sandbox = parser.parseFromString(rawText, 'text/html');


### PR DESCRIPTION
Updates the `DOMParser` security fix comment in `js/app.js` to use descriptive rather than imperative language ("Uses" instead of "Use"). This prevents automated scanners from misinterpreting the comment as an actionable TODO item, aligning with the project's memory instructions. No functional code changes were necessary as the fix was already implemented.

---
*PR created automatically by Jules for task [17045046852991491634](https://jules.google.com/task/17045046852991491634) started by @jaxsnjohnson*