### PR TITLE
🧹 Refactor share function error handling to use UI notification instead of alert

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -4257,6 +4257,20 @@ function showShareButtonSuccessState(btn) {
     }, 1500);
 }
 
+function showShareButtonErrorState(btn) {
+    if (!btn) return;
+    if (!btn.dataset.originalInnerHtml) {
+        btn.dataset.originalInnerHtml = btn.innerHTML;
+    }
+    btn.innerHTML = '❌';
+    if (btn.__shareResetTimeoutId) {
+        clearTimeout(btn.__shareResetTimeoutId);
+    }
+    btn.__shareResetTimeoutId = setTimeout(() => {
+        btn.innerHTML = btn.dataset.originalInnerHtml;
+    }, 1500);
+}
+
 // Global function for onclick
 window.copyFeatureLink = async function(btn, type, name) {
     const featureType = String(type || '').trim().toLowerCase();
@@ -4297,7 +4311,7 @@ window.copyFeatureLink = async function(btn, type, name) {
     }
 
     if (typeof navigator === 'undefined' || !navigator.clipboard || typeof navigator.clipboard.writeText !== 'function') {
-        alert("Sharing is not supported in this browser.");
+        showShareButtonErrorState(btn);
         trackAnalytics('share_copy_unavailable', { featureType, featureName });
         return;
     }
@@ -4308,7 +4322,7 @@ window.copyFeatureLink = async function(btn, type, name) {
         trackAnalytics('share_link_copied', { featureType, featureName });
     } catch (err) {
         console.error('Failed to copy link: ', err);
-        alert("Failed to copy link to clipboard.");
+        showShareButtonErrorState(btn);
     }
 };
 
@@ -4351,7 +4365,7 @@ async function shareCurrentView(btn) {
     }
 
     if (typeof navigator === 'undefined' || !navigator.clipboard || typeof navigator.clipboard.writeText !== 'function') {
-        alert("Sharing is not supported in this browser.");
+        showShareButtonErrorState(btn);
         trackAnalytics('share_copy_unavailable', { featureType, featureName });
         return;
     }
@@ -4362,7 +4376,7 @@ async function shareCurrentView(btn) {
         trackAnalytics('share_link_copied', { featureType, featureName });
     } catch (err) {
         console.error('Failed to copy link: ', err);
-        alert("Failed to copy link to clipboard.");
+        showShareButtonErrorState(btn);
     }
 }
 
@@ -4422,7 +4436,7 @@ async function relaySharedContext(btn) {
     }
 
     if (typeof navigator === 'undefined' || !navigator.clipboard || typeof navigator.clipboard.writeText !== 'function') {
-        alert('Sharing is not supported in this browser.');
+        showShareButtonErrorState(btn);
         trackAnalytics('share_copy_unavailable', { featureType, featureName, entryPoint: 'relay_prompt' });
         return;
     }
@@ -4439,7 +4453,7 @@ async function relaySharedContext(btn) {
         hideShareRelayPrompt('completed');
     } catch (err) {
         console.error('Failed to copy link: ', err);
-        alert('Failed to copy link to clipboard.');
+        showShareButtonErrorState(btn);
     }
 }
 

--- a/tests/share-link-flow.test.js
+++ b/tests/share-link-flow.test.js
@@ -202,6 +202,7 @@ function canUseNativeShare() {
     return false;
 }
 function showShareButtonSuccessState() {}
+function showShareButtonErrorState() {}
 function hideShareRelayPrompt() {}
 
 // eslint-disable-next-line no-eval


### PR DESCRIPTION
🎯 **What:** Replaced the intrusive `alert()` dialogues used when the Clipboard API is unavailable or fails during sharing. A new helper function, `showShareButtonErrorState(btn)`, now temporarily updates the button UI to show an error state ('❌') before restoring the original content.

💡 **Why:** `alert()` provides a poor, blocking user experience. By replacing it with inline UI notifications that mirror the existing success states (`showShareButtonSuccessState`), we improve both code consistency and user experience. 

✅ **Verification:** 
- Modified `js/app.js` and confirmed syntax with `node -c js/app.js`.
- Mocked the new helper in `tests/share-link-flow.test.js`.
- Ran `bun test tests/share-link-flow.test.js` which passed.
- Ran the full test suite (`bun test`) to ensure no regressions were introduced.

✨ **Result:** A more modern, non-blocking UI feedback system for copying map URLs to the clipboard, improving overall application code health and maintainability.

---
*PR created automatically by Jules for task [12208763209535651845](https://jules.google.com/task/12208763209535651845) started by @jaxsnjohnson*