### PR TITLE
🧹 Improve error handling for processChild map data fetching

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -6967,15 +6967,18 @@ async function processChild(childId, level = 0) {
 
         } else if (response.status === 404) {
             console.warn(`Child map file not found: maps/${childId}.json - Marking as 'coming-soon'`);
+            trackAnalytics('child_map_load_failed', { childId, reason: 'not_found' });
             // File not found, treat as coming soon
             return { id: childId, name: childId, status: 'coming-soon', error: 'not found' };
         } else {
             console.warn(`Failed to load child map: ${childId} (${response.statusText}) - Marking as 'coming-soon'`);
+            trackAnalytics('child_map_load_failed', { childId, reason: `http_error_${response.status}` });
             // Other fetch error, treat as coming soon
             return { id: childId, name: childId, status: 'coming-soon', error: `Workspace failed (${response.status})` };
         }
     } catch (error) {
         console.error(`Error processing child ${childId}:`, error);
+        trackAnalytics('child_map_load_failed', { childId, reason: error?.message || 'unknown' });
         // Error during fetch/parse, treat as coming soon
         return { id: childId, name: childId, status: 'coming-soon', error: error.message };
     }


### PR DESCRIPTION
🎯 **What:** Improved error handling for `processChild` child map data fetching logic in `js/app.js` by adding tracking analytics.
💡 **Why:** Background map-fetching operations should gracefully fallback (which they were), but the reason for the failure (404, HTTP error, Parse error) wasn't being observable via the system's normal analytic mechanisms. This brings the fallback handling up to parity with other data fetch failures in the application, ensuring errors are tracked explicitly without adding unneeded user alert dialogs that would block or annoy the user.
✅ **Verification:** Verified via test suite run and `node -c js/app.js`. Also reviewed by the code reviewer agent and marked Correct. 
✨ **Result:** Enhanced observability of map load data.

---
*PR created automatically by Jules for task [944161875281424424](https://jules.google.com/task/944161875281424424) started by @jaxsnjohnson*