### PR TITLE
🧹 Refactor: Extract `finishLoading` logic to `finalizeMapLoadState` in `app.js`

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -4928,6 +4928,39 @@ function startMapLoadingProgress(manifestEntry) {
     }, 150);
 }
 
+function finalizeMapLoadState(requestedMapId, selectedMap, usingAlternateMobileImage, loadStartedAt) {
+    // Defensive: if layers got detached during async startup, attach them again.
+    if (currentMapUnderlay && !map.hasLayer(currentMapUnderlay)) {
+        currentMapUnderlay.addTo(map);
+    }
+    if (currentImageLayer && !map.hasLayer(currentImageLayer)) {
+        currentImageLayer.addTo(map);
+    }
+
+    if (loadingIndicator) {
+        const progressBarEl = loadingIndicator.querySelector('.progress-bar');
+        if (progressBarEl) progressBarEl.style.width = '100%';
+        setTimeout(() => {
+            if (loadingProgressInterval) clearInterval(loadingProgressInterval);
+            loadingProgressInterval = null;
+            loadingIndicator.style.display = 'none';
+            loadingIndicator.classList.remove('initial-loader');
+        }, 300);
+    }
+
+    applySearchParamsToCurrentMap(new URLSearchParams(window.location.search));
+
+    syncMiniMapControl();
+
+    trackAnalytics('map_load_success', {
+        mapId: requestedMapId,
+        mapName: selectedMap.name,
+        imageVariant: usingAlternateMobileImage ? 'mobile' : 'default',
+        durationMs: Math.round(performance.now() - loadStartedAt)
+    });
+    clampFloatingPanels();
+}
+
 // --- Function to Load/Switch Map ---
 async function loadMap(mapId, updateHash = true, preResolvedMap = null) {
     hideShareRelayPrompt('map_loading');
@@ -5024,41 +5057,11 @@ async function loadMap(mapId, updateHash = true, preResolvedMap = null) {
         if (loadingComplete) return;
         loadingComplete = true;
         clearTimeout(loadingTimeout);
-
-        // Defensive: if layers got detached during async startup, attach them again.
-        if (currentMapUnderlay && !map.hasLayer(currentMapUnderlay)) {
-            currentMapUnderlay.addTo(map);
-        }
-        if (currentImageLayer && !map.hasLayer(currentImageLayer)) {
-            currentImageLayer.addTo(map);
-        }
-
-        if (loadingIndicator) {
-            const progressBarEl = loadingIndicator.querySelector('.progress-bar');
-            if (progressBarEl) progressBarEl.style.width = '100%';
-            setTimeout(() => {
-                if (loadingProgressInterval) clearInterval(loadingProgressInterval);
-                loadingProgressInterval = null;
-                loadingIndicator.style.display = 'none';
-                loadingIndicator.classList.remove('initial-loader');
-            }, 300);
-        }
-
-        applySearchParamsToCurrentMap(new URLSearchParams(window.location.search));
-
-        syncMiniMapControl();
-
-        trackAnalytics('map_load_success', {
-            mapId: requestedMapId,
-            mapName: selectedMap.name,
-            imageVariant: usingAlternateMobileImage ? 'mobile' : 'default',
-            durationMs: Math.round(performance.now() - loadStartedAt)
-        });
-        clampFloatingPanels();
+        finalizeMapLoadState(requestedMapId, selectedMap, usingAlternateMobileImage, loadStartedAt);
     }
 
-    preloadImg.onload = function () { finishLoading(); };
-    currentImageLayer.on('load', function () { finishLoading(); });
+    preloadImg.onload = finishLoading;
+    currentImageLayer.on('load', finishLoading);
     currentImageLayer.on('error', function () {
         if (loadingComplete) return;
         loadingComplete = true;


### PR DESCRIPTION
🎯 **What:** Extracted the inner nested body of `finishLoading` (inside `loadMap`) into a new top-level helper function named `finalizeMapLoadState` in `js/app.js`.

💡 **Why:** `loadMap` is a massive function, and keeping `finishLoading` as a 35-line closure tightly coupled within it made the flow harder to parse. Moving the logic to a module-scoped function simplifies the closure to just state-checks and defers side-effects appropriately, isolating concerns.

✅ **Verification:** Verified by checking AST syntax validity via `node -c js/app.js` and executing the full testing suite via `bun test` to guarantee no state-tracking regressions were introduced.

✨ **Result:** Improved readability and testability of map loading side-effects without altering functionality.

---
*PR created automatically by Jules for task [4024802225088908700](https://jules.google.com/task/4024802225088908700) started by @jaxsnjohnson*