### PR TITLE
🎨 Palette: Add hover and focus-visible states to map editor accordions

### DIFF
--- a/css/map-editor.css
+++ b/css/map-editor.css
@@ -87,6 +87,19 @@
     cursor: pointer;
     user-select: none;
     list-style: none; /* remove native triangle on most browsers */
+    transition: background-color 0.2s ease, opacity 0.2s ease;
+    border-radius: 4px;
+    padding: 2px 4px;
+    margin: -2px -4px;
+}
+
+.map-editor-section-header:hover {
+    background-color: var(--highlight-bg, rgba(212, 163, 106, 0.15));
+}
+
+.map-editor-section-header:focus-visible {
+    outline: 2px solid var(--focus-ring, #0f5fbf);
+    outline-offset: 2px;
 }
 
 .map-editor-section-header::-webkit-details-marker {


### PR DESCRIPTION
💡 **What:** Added `:hover` and `:focus-visible` pseudo-classes along with a `transition` to the `.map-editor-section-header` elements.\n🎯 **Why:** These elements act as `<summary>` tags for accordions but lacked visual interaction states. Adding clear hover and focus feedback makes the map editor more accessible for keyboard users and more intuitive for mouse users.\n♿ **Accessibility:** Users navigating via the keyboard will now see a clear outline when focusing the accordion headers, and mouse users get subtle background color feedback when hovering over them.\n\nThis change is purely CSS-based, keeping the enhancement lightweight and within established patterns. No tests are broken.

---
*PR created automatically by Jules for task [10550402732815668358](https://jules.google.com/task/10550402732815668358) started by @jaxsnjohnson*