### PR TITLE
🛡️ Sentinel: [HIGH] Fix DOM-based XSS in WIP Notice rendering

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -10,3 +10,7 @@
 **Vulnerability:** DOM-based XSS via `tab.html` assignment directly to `innerHTML` in `hydrateHelpModal`.
 **Learning:** Configurable or injected HTML content was not passed through a sanitizer before rendering, allowing arbitrary script execution if configuration data is tampered with.
 **Prevention:** Always use `DOMPurify.sanitize()` when injecting untrusted or external HTML. Implement an inline `escapeHtml()` fallback when `DOMPurify` is conditionally loaded to ensure a "fail-closed" security posture.
+## 2025-05-04 - Unsanitized WIP Notice Popup
+**Vulnerability:** DOM-based XSS via `wipPopup.innerHTML` where configurable strings from `copy.wipNotice` are directly injected without escaping.
+**Learning:** Configurable HTML elements or strings that bypass rendering methods using innerHTML directly are prone to script injections, particularly when they map from arrays.
+**Prevention:** Always use `DOMPurify.sanitize()` or an explicit `escapeHtml` fallback before rendering arrays of configured strings or content into `.innerHTML`.

--- a/js/app-config.js
+++ b/js/app-config.js
@@ -551,7 +551,11 @@
         const wipPopup = documentRef.getElementById('wip-popup');
         const notices = get('copy.wipNotice', []);
         if (wipPopup && Array.isArray(notices)) {
-            wipPopup.innerHTML = notices.map((line) => `<p>${String(line)}</p>`).join('');
+            const safeNotices = notices.map((line) => {
+                const strLine = String(line);
+                return `<p>${typeof DOMPurify !== 'undefined' ? DOMPurify.sanitize(strLine) : escapeHtml(strLine)}</p>`;
+            }).join('');
+            wipPopup.innerHTML = safeNotices;
             wipPopup.hidden = !get('features.wipNotice', true);
         }
 


### PR DESCRIPTION
Fixes a DOM-based Stored XSS vulnerability in `js/app-config.js` when mapping arrays of notice text and setting them inside `wipPopup.innerHTML`. Sanitization is now applied per line text before interpolation.

---
*PR created automatically by Jules for task [11023160233999996157](https://jules.google.com/task/11023160233999996157) started by @jaxsnjohnson*