### PR TITLE
🎨 Palette: Add keyboard focus-visible styling to theme toggle

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -9,3 +9,7 @@
 ## 2026-04-29 - Map Chooser Image Accessibility
 **Learning:** Images inside interactive components like buttons that already provide rich text context via `aria-labelledby` cause redundant and noisy screen reader announcements if they retain their descriptive `alt` text.
 **Action:** Set the image `alt` attribute to an empty string (`alt=''`) and add `aria-hidden='true'` to explicitly hide decorative or redundant images from the accessibility tree when the parent component already provides the necessary context.
+
+## 2026-05-01 - Hidden Input Keyboard Accessibility
+**Learning:** Custom UI components (like toggles) that use a visually hidden `<input>` element with `opacity: 0` alongside a custom surrogate element (like a `.slider` div) lose default browser focus rings. The invisible input still receives focus via Tab navigation, but no visual indicator is shown to the user.
+**Action:** When hiding native inputs for custom styling, always apply a `:focus-visible` ring on the custom surrogate element using the adjacent sibling combinator (e.g., `input:focus-visible + .slider`).

--- a/css/style.css
+++ b/css/style.css
@@ -2089,6 +2089,7 @@ body.embedded-view #share-relay-coachmark {
 .theme-switch input { opacity: 0; width: 0; height: 0; }
 .slider { position: absolute; cursor: pointer; top: 0; left: 0; right: 0; bottom: 0; background-color: var(--slider-bg); transition: background-color var(--theme-transition-base) var(--theme-transition-ease); }
 .slider:before { position: absolute; content: ""; height: 18px; width: 18px; left: 3px; bottom: 3px; background-color: white; transition: transform var(--theme-transition-base) var(--theme-transition-ease); }
+.theme-switch input:focus-visible + .slider { outline: 2px solid var(--focus-ring); outline-offset: 2px; }
 input:checked + .slider { background-color: var(--slider-checked-bg); }
 input:checked + .slider:before { transform: translateX(26px); }
 .slider.round { border-radius: 24px; }


### PR DESCRIPTION
💡 What: Added `:focus-visible` styles to the `.slider` of the theme toggle switch.
🎯 Why: The native `<input>` is visually hidden, which meant the default browser focus ring was invisible. This broke keyboard accessibility, leaving users unsure if the toggle was focused.
♿ Accessibility: Ensures keyboard users receive visual feedback when tabbing to the theme toggle.

---
*PR created automatically by Jules for task [9847387370822211368](https://jules.google.com/task/9847387370822211368) started by @jaxsnjohnson*