### PR TITLE
🎨 Palette: Make filter group headers keyboard accessible

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -13,3 +13,6 @@
 ## 2026-05-01 - Hidden Input Keyboard Accessibility
 **Learning:** Custom UI components (like toggles) that use a visually hidden `<input>` element with `opacity: 0` alongside a custom surrogate element (like a `.slider` div) lose default browser focus rings. The invisible input still receives focus via Tab navigation, but no visual indicator is shown to the user.
 **Action:** When hiding native inputs for custom styling, always apply a `:focus-visible` ring on the custom surrogate element using the adjacent sibling combinator (e.g., `input:focus-visible + .slider`).
+## 2023-10-24 - Make filter group headers keyboard accessible
+**Learning:** Adding `tabindex="0"` and `role="button"` makes custom group headers keyboard focusable, but requires an explicit `keydown` listener for 'Enter' and 'Space'. The default 'Space' behavior scrolls the page, requiring `e.preventDefault()`. Custom focus outlines via `:focus-visible` can cause layout shifts if not balanced with equal positive padding and negative margin (e.g., `padding: 2px 4px; margin: -2px -4px;`).
+**Action:** When implementing custom toggle elements, always add the `keydown` event listener, suppress default spacebar scrolling, and use the padding/margin trick to safely add focus rings without breaking the layout.

--- a/css/style.css
+++ b/css/style.css
@@ -1666,6 +1666,17 @@ body.embedded-view #share-relay-coachmark {
     display: flex;
     align-items: center;
     font-weight: bold; /* Make the group name stand out */
+    padding: 2px 4px;
+    margin: -2px -4px;
+    border-radius: 4px;
+    transition: background-color 0.2s ease;
+}
+.filter-group-header:focus-visible {
+    outline: 2px solid var(--focus-ring);
+    outline-offset: 2px;
+}
+.filter-group-header:hover {
+    background-color: var(--highlight-bg, rgba(212, 163, 106, 0.15));
 }
 .filter-chevron-icon {
     display: inline-flex;

--- a/js/app.js
+++ b/js/app.js
@@ -4052,6 +4052,9 @@ function createRegionFilterGroupDOM(groupName, values) {
 
     const groupHeader = document.createElement('div');
     groupHeader.className = 'filter-group-header';
+    groupHeader.setAttribute('role', 'button');
+    groupHeader.setAttribute('tabindex', '0');
+    groupHeader.setAttribute('aria-expanded', 'false');
     groupHeader.innerHTML = `
         <span class="filter-chevron-icon" aria-hidden="true">
             <i class="ui-icon" data-lucide="chevron-right"></i>
@@ -6402,12 +6405,27 @@ poiFilterContainer.addEventListener('click', (e) => {
     if (header) {
         const group = header.closest('.filter-group');
         if (group) {
-            group.classList.toggle('closed');
+            const isClosed = group.classList.toggle('closed');
+            header.setAttribute('aria-expanded', !isClosed);
         }
     }
     e.stopPropagation();
 });
 
+// Allow keyboard toggling of filter groups
+poiFilterContainer.addEventListener('keydown', (e) => {
+    if (e.key === 'Enter' || e.key === ' ') {
+        const header = e.target.closest('.filter-group-header');
+        if (header) {
+            e.preventDefault();
+            const group = header.closest('.filter-group');
+            if (group) {
+                const isClosed = group.classList.toggle('closed');
+                header.setAttribute('aria-expanded', !isClosed);
+            }
+        }
+    }
+});
 
 // --- Measurement Tool Logic ---
 function handleMeasurementClick(e) {


### PR DESCRIPTION
💡 What: Added `role="button"`, `tabindex="0"`, `aria-expanded` and a keydown listener (Enter/Space) to filter group headers. Also added a focus ring.
🎯 Why: Users could not focus or expand/collapse filter groups using a keyboard.
📸 Before/After: Filter groups now display a focus ring when navigated via keyboard and can be toggled using Enter/Space.
♿ Accessibility: Improves keyboard navigation and provides screen readers with context (`aria-expanded`) for filter groups.

---
*PR created automatically by Jules for task [7079354555669612040](https://jules.google.com/task/7079354555669612040) started by @jaxsnjohnson*