### PR TITLE
🎨 Palette: Add keyboard navigation to theme toggle

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -16,3 +16,6 @@
 ## 2023-10-24 - Make filter group headers keyboard accessible
 **Learning:** Adding `tabindex="0"` and `role="button"` makes custom group headers keyboard focusable, but requires an explicit `keydown` listener for 'Enter' and 'Space'. The default 'Space' behavior scrolls the page, requiring `e.preventDefault()`. Custom focus outlines via `:focus-visible` can cause layout shifts if not balanced with equal positive padding and negative margin (e.g., `padding: 2px 4px; margin: -2px -4px;`).
 **Action:** When implementing custom toggle elements, always add the `keydown` event listener, suppress default spacebar scrolling, and use the padding/margin trick to safely add focus rings without breaking the layout.
+## 2026-05-06 - Programmatic Checkbox Toggling
+**Learning:** When programmatically toggling the `checked` property of a native `<input type="checkbox">` in a custom `keydown` event listener (e.g., to handle 'Space' or 'Enter'), the browser does not automatically fire a 'change' event like it does for a physical click. This breaks any downstream logic relying on 'change' listeners.
+**Action:** Always explicitly dispatch a new 'change' event (e.g., `element.dispatchEvent(new Event('change'))`) immediately after programmatically mutating the `checked` state to ensure complete functionality parity with native clicks.

--- a/js/app.js
+++ b/js/app.js
@@ -5685,6 +5685,15 @@ if (systemThemeMediaQuery) {
     }
 }
 
+themeToggle.addEventListener('keydown', (e) => {
+    if (e.key === 'Enter' || e.key === ' ') {
+        e.preventDefault(); // Prevent page scroll on Space
+        themeToggle.checked = !themeToggle.checked;
+        // Manually dispatch change event since we are changing the property programmatically
+        themeToggle.dispatchEvent(new Event('change'));
+    }
+});
+
 themeToggle.addEventListener('change', () => {
     unlockAdvancedControls('theme_toggle');
     const newThemePreference = themeToggle.checked ? 'dark' : 'light';


### PR DESCRIPTION
🎨 Palette: Keyboard Accessibility for Theme Toggle

💡 **What:** Added keyboard navigation support (Enter/Space keys) to the theme toggle switch.
🎯 **Why:** The native `<input type="checkbox">` is visually hidden (opacity: 0) to allow for the custom pill-shaped toggle design. While it could receive focus via the Tab key, it was completely unresponsive to the `Enter` key (which checkboxes don't natively respond to) and the `Space` key behavior could be inconsistent or cause page scrolling without explicit handling. 
♿ **Accessibility:** Users navigating via keyboard can now seamlessly toggle the application's light/dark mode using standard keyboard interaction patterns without unexpected page scrolls.

---
*PR created automatically by Jules for task [4802513897754512415](https://jules.google.com/task/4802513897754512415) started by @jaxsnjohnson*