### PR TITLE
🎨 Palette: Keyboard Accessibility for Theme Toggle

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -9,3 +9,7 @@
 ## 2026-04-29 - Map Chooser Image Accessibility
 **Learning:** Images inside interactive components like buttons that already provide rich text context via `aria-labelledby` cause redundant and noisy screen reader announcements if they retain their descriptive `alt` text.
 **Action:** Set the image `alt` attribute to an empty string (`alt=''`) and add `aria-hidden='true'` to explicitly hide decorative or redundant images from the accessibility tree when the parent component already provides the necessary context.
+
+## 2026-05-06 - Custom Toggles and Keyboard Accessibility
+**Learning:** Custom toggle elements that rely on visually hidden native inputs (`<input type="checkbox" opacity="0">`) often lack default keyboard action triggers for keys like 'Enter', breaking accessibility for users trying to intuitively switch themes.
+**Action:** Attach an explicit `keydown` event listener to handle 'Enter' to trigger the change action (native `<input>` handles 'Space' automatically). Manually toggle the checked property and dispatch a `change` event so other listeners react accordingly. Ensure `e.preventDefault()` is called to prevent form submissions.

--- a/js/app.js
+++ b/js/app.js
@@ -5685,25 +5685,35 @@ if (systemThemeMediaQuery) {
     }
 }
 
-themeToggle.addEventListener('change', () => {
-    unlockAdvancedControls('theme_toggle');
-    const newThemePreference = themeToggle.checked ? 'dark' : 'light';
-    setThemePreference(newThemePreference);
-    const effectiveTheme = resolveEffectiveTheme(newThemePreference);
-    trackAnalytics('theme_changed', { theme: effectiveTheme, preference: newThemePreference });
+if (themeToggle) {
+    themeToggle.addEventListener('change', () => {
+        unlockAdvancedControls('theme_toggle');
+        const newThemePreference = themeToggle.checked ? 'dark' : 'light';
+        setThemePreference(newThemePreference);
+        const effectiveTheme = resolveEffectiveTheme(newThemePreference);
+        trackAnalytics('theme_changed', { theme: effectiveTheme, preference: newThemePreference });
 
-    // Update audio track if sound is enabled
-    if (soundEnabled) {
-        ensureAmbientTracksLoaded();
-        if (effectiveTheme === 'dark') {
-            fadeAudio(lightAmbient, 0);
-            fadeAudio(darkAmbient, 0.3);
-        } else {
-            fadeAudio(darkAmbient, 0);
-            fadeAudio(lightAmbient, 0.3);
+        // Update audio track if sound is enabled
+        if (soundEnabled) {
+            ensureAmbientTracksLoaded();
+            if (effectiveTheme === 'dark') {
+                fadeAudio(lightAmbient, 0);
+                fadeAudio(darkAmbient, 0.3);
+            } else {
+                fadeAudio(darkAmbient, 0);
+                fadeAudio(lightAmbient, 0.3);
+            }
         }
-    }
-});
+    });
+
+    themeToggle.addEventListener('keydown', (e) => {
+        if (e.key === 'Enter') {
+            e.preventDefault();
+            themeToggle.checked = !themeToggle.checked;
+            themeToggle.dispatchEvent(new Event('change'));
+        }
+    });
+}
 
 // --- Sound Control Logic ---
 function ensureAmbientAudioLoaded(audioElement) {


### PR DESCRIPTION
🎨 Palette: Keyboard Accessibility for Theme Toggle

💡 **What:** Added an explicit `keydown` event listener to the custom theme toggle (`#theme-checkbox`). The listener intercepts the 'Enter' key, prevents default actions (like unwanted form submission), manually toggles the state, and dispatches a 'change' event to switch the theme.

🎯 **Why:** Custom toggle components that rely on a visually hidden native `<input type="checkbox">` default to only supporting the 'Space' key for activation. Keyboard-only users often expect interactive toggle switch UI patterns to respond to the 'Enter' key. This minor change bridges that expectation gap, making the theme switch much more intuitive and accessible for power users and screen readers navigating via the keyboard.

♿ **Accessibility:**
- Ensures 'Enter' key support for custom visually hidden toggle elements, complementing the native 'Space' key behavior.
- Documented this component-specific learning in `.jules/palette.md` to prevent similar accessibility gaps in future custom toggles.

---
*PR created automatically by Jules for task [1512142416381713438](https://jules.google.com/task/1512142416381713438) started by @jaxsnjohnson*