### PR TITLE
🎨 Palette: Add confirmation for deleting features

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -19,3 +19,7 @@
 ## 2026-05-06 - Programmatic Checkbox Toggling
 **Learning:** When programmatically toggling the `checked` property of a native `<input type="checkbox">` in a custom `keydown` event listener (e.g., to handle 'Space' or 'Enter'), the browser does not automatically fire a 'change' event like it does for a physical click. This breaks any downstream logic relying on 'change' listeners.
 **Action:** Always explicitly dispatch a new 'change' event (e.g., `element.dispatchEvent(new Event('change'))`) immediately after programmatically mutating the `checked` state to ensure complete functionality parity with native clicks.
+
+## 2026-05-15 - Destructive Actions and Confirmation
+**Learning:** Destructive actions without confirmation dialogs can easily lead to accidental data loss and frustration. Users often click quickly and don't realize the consequences of their action until it's too late.
+**Action:** Always wrap destructive actions, such as deleting a feature in a map editor, with a confirmation dialog (e.g., `window.confirm`) to explicitly require user consent and prevent accidental data loss.

--- a/js/map-editor.js
+++ b/js/map-editor.js
@@ -1092,6 +1092,7 @@
 
     function deleteSelectedFeature() {
         if (!state.selectedFeature) return;
+        if (!window.confirm('Are you sure you want to delete this feature?')) return;
         const collection = getCurrentFeatureCollection(state.selectedFeature.mode);
         collection.splice(state.selectedFeature.index, 1);
         deselectFeature();


### PR DESCRIPTION
This PR adds a small UX improvement to the Map Editor. It wraps the feature deletion action in a `window.confirm` dialog to require explicit user consent, preventing accidental data loss when users click the "Delete Selected" button.

### 💡 What: The UX enhancement added
Added a `window.confirm` dialog to the `deleteSelectedFeature` function in the map editor.

### 🎯 Why: The user problem it solves
Users could previously click the "Delete Selected" button and instantly lose a mapped feature (POI, region, line). Destructive actions without confirmation are a common source of frustration and accidental data loss. This forces a deliberate choice before completing the deletion.

### ♿ Accessibility
This provides cognitive accessibility by giving the user an opportunity to recover from an accidental or mis-targeted click, rather than silently failing and causing data loss.

---
*PR created automatically by Jules for task [7347153553966847323](https://jules.google.com/task/7347153553966847323) started by @jaxsnjohnson*