### PR TITLE
⚡ Bolt: Optimize DOM iterations in filter and search loops

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -51,3 +51,6 @@
 ## 2025-06-01 - O(1) Set Lookups in Layer Filters
 **Learning:** Using `Array.includes` inside iterative map layer loops (like `updateVisibleLines`) creates an $O(m \times n)$ overhead when matching features against many active filter options.
 **Action:** Always collect user filter selections into a `Set` instead of an `Array` prior to iterating over map elements so checking visibility stays at $O(1)$ per layer.
+## 2023-11-15 - O(1) Bypassing of Filter Collection Iteration
+**Learning:** Even with a pre-cached live `HTMLCollection`, iterating over all filter checkboxes to build an active `Set` is an $O(n)$ operation. When a "Toggle All" or "Master" checkbox state implicitly overrides all individual filter selections (acting as a wildcard), this iteration is wasted CPU time during frequent filtering operations.
+**Action:** In frontend filtering logic, when a "Toggle All" overriding state exists, compute the `allChecked` boolean *before* iterating over the individual filters. Bypass the entire DOM iteration and `Set` allocation using `if (!allChecked) { ... }` to achieve an O(1) early return and avoid redundant calculations.

--- a/js/app.js
+++ b/js/app.js
@@ -3480,8 +3480,9 @@ function searchMapMarkers(searchTerm, results, allPoiGroupsChecked, activeSpecif
 function searchMapRegions(searchTerm, results, searchFiltersCurrentMap) {
     if (!searchFiltersCurrentMap || !currentRegionGroup) return;
 
+    const allRegionTypesChecked = filterToggleAllCheckbox.checked && !filterToggleAllCheckbox.indeterminate;
     const activeRegionTypeFilters = new Set();
-    if (poiFilterCheckboxesLive) {
+    if (!allRegionTypesChecked && poiFilterCheckboxesLive) {
         for (let i = 0; i < poiFilterCheckboxesLive.length; i++) {
             const checkbox = poiFilterCheckboxesLive[i];
             if (checkbox.type === 'checkbox' &&
@@ -3491,7 +3492,6 @@ function searchMapRegions(searchTerm, results, searchFiltersCurrentMap) {
             }
         }
     }
-    const allRegionTypesChecked = filterToggleAllCheckbox.checked && !filterToggleAllCheckbox.indeterminate;
 
     currentRegionGroup.eachLayer((layer) => {
             const region = layer.regionData;
@@ -3524,8 +3524,9 @@ function searchMapRegions(searchTerm, results, searchFiltersCurrentMap) {
 function searchMapLines(searchTerm, results, searchFiltersCurrentMap) {
     if (!searchFiltersCurrentMap || !currentRoadGroup) return;
 
+    const allLineTypesChecked = filterToggleAllCheckbox.checked && !filterToggleAllCheckbox.indeterminate;
     const activeLineTypeFilters = new Set();
-    if (poiFilterCheckboxesLive) {
+    if (!allLineTypesChecked && poiFilterCheckboxesLive) {
         for (let i = 0; i < poiFilterCheckboxesLive.length; i++) {
             const checkbox = poiFilterCheckboxesLive[i];
             if (checkbox.type === 'checkbox' &&
@@ -3535,7 +3536,6 @@ function searchMapLines(searchTerm, results, searchFiltersCurrentMap) {
             }
         }
     }
-    const allLineTypesChecked = filterToggleAllCheckbox.checked && !filterToggleAllCheckbox.indeterminate;
 
     currentRoadGroup.eachLayer((layer) => {
             const line = layer.roadData;
@@ -3643,8 +3643,9 @@ function updateVisibleMarkersAndSearch() {
     const searchTerm = normalizeSearchValue(poiSearchInput.value);
     const results = [];
 
+    const allPoiGroupsChecked = filterToggleAllCheckbox.checked && !filterToggleAllCheckbox.indeterminate;
     const activeSpecificGroupFilters = new Set();
-    if (poiFilterCheckboxesLive) {
+    if (!allPoiGroupsChecked && poiFilterCheckboxesLive) {
         for (let i = 0; i < poiFilterCheckboxesLive.length; i++) {
             const checkbox = poiFilterCheckboxesLive[i];
             if (checkbox.type === 'checkbox' &&
@@ -3655,7 +3656,6 @@ function updateVisibleMarkersAndSearch() {
             }
         }
     }
-    const allPoiGroupsChecked = filterToggleAllCheckbox.checked && !filterToggleAllCheckbox.indeterminate;
     const searchFiltersCurrentMap = currentSearchScope === SEARCH_SCOPE_MAP && !!searchTerm;
 
     searchMapMarkers(searchTerm, results, allPoiGroupsChecked, activeSpecificGroupFilters, searchFiltersCurrentMap);
@@ -5198,9 +5198,12 @@ function addRegionsToMap(mapId) {
 function updateVisibleRegions() {
     if (!currentRegionGroup) return;
 
+    // Check the master toggle state
+    const allTypesChecked = filterToggleAllCheckbox.checked && !filterToggleAllCheckbox.indeterminate;
+
     // Get the currently checked region type filters (the individual values)
     const valueFilterValues = new Set();
-    if (poiFilterCheckboxesLive) {
+    if (!allTypesChecked && poiFilterCheckboxesLive) {
         for (let i = 0; i < poiFilterCheckboxesLive.length; i++) {
             const checkbox = poiFilterCheckboxesLive[i];
             if (checkbox.type === 'checkbox' &&
@@ -5210,9 +5213,6 @@ function updateVisibleRegions() {
             }
         }
     }
-
-    // Check the master toggle state
-    const allTypesChecked = filterToggleAllCheckbox.checked && !filterToggleAllCheckbox.indeterminate;
 
     currentRegionGroup.eachLayer(layer => {
         const region = layer.regionData;
@@ -6314,9 +6314,11 @@ if (activeFiltersContainer) {
 function updateVisibleLines() {
     if (!currentRoadGroup) return;
 
+    const allTypesChecked = filterToggleAllCheckbox.checked && !filterToggleAllCheckbox.indeterminate;
+
     // ⚡ Bolt: Use a Set for O(1) lookups inside the layer iteration loop below
     const typeFilterValues = new Set();
-    if (poiFilterCheckboxesLive) {
+    if (!allTypesChecked && poiFilterCheckboxesLive) {
         for (let i = 0; i < poiFilterCheckboxesLive.length; i++) {
             const checkbox = poiFilterCheckboxesLive[i];
             if (checkbox.type === 'checkbox' &&
@@ -6326,7 +6328,6 @@ function updateVisibleLines() {
             }
         }
     }
-    const allTypesChecked = filterToggleAllCheckbox.checked && !filterToggleAllCheckbox.indeterminate;
 
     currentRoadGroup.eachLayer(layer => {
         const road = layer.roadData;


### PR DESCRIPTION
💡 What: Optimized `updateVisibleMarkersAndSearch`, `searchMapRegions`, `searchMapLines`, `updateVisibleRegions`, and `updateVisibleLines` in `js/app.js` to compute the "Toggle All" master boolean *before* iterating over the `poiFilterCheckboxesLive` HTMLCollection.

🎯 Why: During frequent layer filtering and search operations, building a `Set` of active specific group filters is an $O(n)$ operation (where $n$ is the number of individual filter checkboxes). However, when the master "Toggle All" checkbox is fully checked, this iteration is completely redundant, as the master state implicitly overrides the individual states downstream anyway. 

📊 Impact: Reduces CPU time and DOM property access in hot render loops by bypassing $O(n)$ checkbox iterations when all filters are enabled (the default state). Achieves an $O(1)$ early return.

🔬 Measurement: Run map interactions (zooming, searching) with all filters enabled and observe improved responsiveness, as the filter evaluation functions skip building sets for hundreds of individual toggle values. Run tests to ensure identical map rendering logic is preserved.

---
*PR created automatically by Jules for task [3763322415489986576](https://jules.google.com/task/3763322415489986576) started by @jaxsnjohnson*