### PR TITLE
🎨 Palette: Add focus-visible styles to map editor interactive elements

### DIFF
--- a/css/map-editor.css
+++ b/css/map-editor.css
@@ -153,6 +153,15 @@ details[open] .map-editor-section-header h2::before {
     font: inherit;
 }
 
+#editor-tree-search:focus-visible,
+.map-editor-form input:focus-visible,
+.map-editor-form select:focus-visible,
+.map-editor-form textarea:focus-visible,
+#editor-feature-search:focus-visible {
+    outline: 2px solid var(--focus-ring, #0f5fbf);
+    outline-offset: 2px;
+}
+
 #editor-tree-search {
     margin-bottom: 16px;
 }
@@ -209,6 +218,16 @@ details[open] .map-editor-section-header h2::before {
     color: inherit;
     border-radius: 10px;
     font: inherit;
+}
+
+.map-editor-tree-toggle:focus-visible,
+.map-editor-tree-item:focus-visible,
+.map-editor-toolbar button:focus-visible,
+.map-editor-export-bar button:focus-visible,
+.map-editor-panel-header button:focus-visible,
+.map-editor-feature-entry:focus-visible {
+    outline: 2px solid var(--focus-ring, #0f5fbf);
+    outline-offset: 2px;
 }
 
 .map-editor-tree-toggle,


### PR DESCRIPTION
🎨 Palette: Add focus visible styles for map editor elements

💡 What: Added `:focus-visible` CSS rules for inputs, selects, textareas, buttons, tree items, and toggles within `map-editor.css`.
🎯 Why: Without clear focus indicators, users relying on keyboard navigation cannot effectively tell which element in the map editor is currently active.
📸 Before/After: Verified with Playwright screenshots.
♿ Accessibility: Ensures consistent visual feedback for keyboard users across the entire editor interface.

---
*PR created automatically by Jules for task [12790488940506433662](https://jules.google.com/task/12790488940506433662) started by @jaxsnjohnson*