### PR TITLE
🛡️ Sentinel: [HIGH] Fix DOM-based XSS in single-quoted event handlers

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -14,3 +14,7 @@
 **Vulnerability:** DOM-based XSS via `wipPopup.innerHTML` where configurable strings from `copy.wipNotice` are directly injected without escaping.
 **Learning:** Configurable HTML elements or strings that bypass rendering methods using innerHTML directly are prone to script injections, particularly when they map from arrays.
 **Prevention:** Always use `DOMPurify.sanitize()` or an explicit `escapeHtml` fallback before rendering arrays of configured strings or content into `.innerHTML`.
+## 2025-05-24 - [DOM-based XSS in Single-Quoted Event Handlers]
+**Vulnerability:** XSS via `escapeForSingleQuotedAttribute` when the output is rendered using `innerHTML`. The function escaped backslashes and single quotes correctly for a JavaScript string context, but failed to escape HTML entities (like `&apos;`). When assigned to `innerHTML`, the browser decodes `&apos;` to `'` *before* evaluating the `onclick` attribute, breaking out of the single quotes and executing arbitrary code.
+**Learning:** When sanitizing strings that will be placed inside inline event handlers (like `onclick='...'`) and injected via `innerHTML`, the escaping must handle both JavaScript string boundaries *and* HTML entity decoding.
+**Prevention:** Always escape ampersands (`&`) to `&amp;` alongside quotes and backslashes to prevent HTML parsers from decoding entities prematurely when injecting attributes into the DOM via strings.

--- a/js/app.js
+++ b/js/app.js
@@ -298,6 +298,10 @@ function escapeHtml(value) {
 
 function escapeForSingleQuotedAttribute(value) {
     return String(value || '')
+        .replace(/&/g, '&amp;')
+        .replace(/</g, '&lt;')
+        .replace(/>/g, '&gt;')
+        .replace(/"/g, '&quot;')
         .replace(/\\/g, '\\\\')
         .replace(/'/g, "\\'");
 }

--- a/tests/createPopupContent.test.js
+++ b/tests/createPopupContent.test.js
@@ -62,7 +62,7 @@ assert.ok(
 );
 
 assert.ok(
-    popupHtml.includes(`onclick="copyFeatureLink(this, 'poi', 'Old <Lin> \"Watch\" O\\\\Brien')"`),
+    popupHtml.includes(`onclick="copyFeatureLink(this, 'poi', 'Old &lt;Lin&gt; &quot;Watch&quot; O\\\\Brien')"`),
     'share link handler argument should preserve backslashes safely'
 );
 


### PR DESCRIPTION
This PR fixes a critical Cross-Site Scripting (XSS) vulnerability.

**Vulnerability Details:**
The function `escapeForSingleQuotedAttribute` only escaped `\` and `'`. When placing these escaped strings into an HTML attribute defined by single quotes (e.g., `onclick="doThing('${escaped}')"`), the HTML parser evaluates the string first. If an attacker inputs `&apos;); alert(1); //`, the function doesn't change it. When injected via `innerHTML`, the browser decodes `&apos;` to `'`, resulting in `onclick="doThing(''); alert(1); //')"`.

**Fix:**
This patch adds standard HTML entity encoding for `&`, `<`, `>`, and `"` before handling the JS-specific escapes, effectively nullifying the vulnerability.

Tests have been run and verified.

---
*PR created automatically by Jules for task [16824782546572055088](https://jules.google.com/task/16824782546572055088) started by @jaxsnjohnson*