### PR TITLE
🧹 [Code Health] Remove unused `getViewportHeight` function

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -1275,10 +1275,6 @@ function syncBottomBarHeightVariable() {
     rootElement.style.setProperty('--bottom-link-bar-height', `${bottomBarHeight}px`);
 }
 
-function getViewportHeight() {
-    return window.visualViewport ? window.visualViewport.height : window.innerHeight;
-}
-
 function clampFloatingPanels() {
     if (!mobileLayoutV2Enabled || isMobileLayoutActive) return;
     [routePanel, sessionToolkitPanel, gmPill].forEach((panel) => {


### PR DESCRIPTION
🎯 **What:** Removed the `getViewportHeight` function from `js/app.js`.
💡 **Why:** A codebase-wide search confirmed that `getViewportHeight` is dead code and not called anywhere. Removing it improves maintainability and cleans up the file.
✅ **Verification:** Validated that the codebase tests continue to pass via `bun test tests/` and confirmed via `grep` that no usages exist.
✨ **Result:** Cleaned up unused dead code without impacting functionality.

---
*PR created automatically by Jules for task [13269135295747836766](https://jules.google.com/task/13269135295747836766) started by @jaxsnjohnson*