### PR TITLE
🧹 Remove unused getMobileMapListEntryCount function

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -1493,11 +1493,6 @@ function renderMapBlurbContent(mapInfo = getMapRuntimeData(currentlyLoadedMapId)
     mapBlurbElement.innerHTML = desktopBlurb;
 }
 
-function getMobileMapListEntryCount() {
-    if (!mapListElement) return 0;
-    return mapListElement.querySelectorAll('.map-item[data-map-id], .folder-header[data-map-id]').length;
-}
-
 function syncMobileMapMeta(mapInfo, visibilityState) {
     renderMapBlurbContent(mapInfo);
     if (!mobileSearchPanelTitle) return;

--- a/tests/renderMapBlurbContent.test.js
+++ b/tests/renderMapBlurbContent.test.js
@@ -15,7 +15,7 @@ const appSource = fs.readFileSync('js/app.js', 'utf8');
 const escapeHtmlStart = appSource.indexOf('function escapeHtml(value) {');
 const escapeHtmlEnd = appSource.indexOf('function escapeForSingleQuotedAttribute(value) {');
 const renderStart = appSource.indexOf('function renderMapBlurbContent');
-const renderEnd = appSource.indexOf('function getMobileMapListEntryCount');
+const renderEnd = appSource.indexOf('function syncMobileMapMeta');
 
 if (escapeHtmlStart === -1 || escapeHtmlEnd === -1 || renderStart === -1 || renderEnd === -1) {
     throw new Error('Could not locate required functions in js/app.js');


### PR DESCRIPTION
🎯 **What:** The code health issue addressed
Removed the unused function `getMobileMapListEntryCount` from `js/app.js`. Also updated `tests/renderMapBlurbContent.test.js` which was relying on this removed function's declaration string as an extraction boundary marker.

💡 **Why:** How this improves maintainability
Removing dead code reduces confusion, slightly reduces bundle size, and improves overall codebase clarity. Fixing the test prevents unexpected CI failures.

✅ **Verification:** How you confirmed the change is safe
Ran `bun test tests/renderMapBlurbContent.test.js` successfully and then ran the full test suite (`bun test tests/`). All tests passed.

✨ **Result:** The improvement achieved
A slightly cleaner `js/app.js` file with robust isolated tests.

---
*PR created automatically by Jules for task [9418823875725572891](https://jules.google.com/task/9418823875725572891) started by @jaxsnjohnson*