### PR TITLE
🎨 Palette: Add contextual feature name to delete confirmation prompt

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -9,3 +9,19 @@
 ## 2026-04-29 - Map Chooser Image Accessibility
 **Learning:** Images inside interactive components like buttons that already provide rich text context via `aria-labelledby` cause redundant and noisy screen reader announcements if they retain their descriptive `alt` text.
 **Action:** Set the image `alt` attribute to an empty string (`alt=''`) and add `aria-hidden='true'` to explicitly hide decorative or redundant images from the accessibility tree when the parent component already provides the necessary context.
+
+## 2026-05-01 - Hidden Input Keyboard Accessibility
+**Learning:** Custom UI components (like toggles) that use a visually hidden `<input>` element with `opacity: 0` alongside a custom surrogate element (like a `.slider` div) lose default browser focus rings. The invisible input still receives focus via Tab navigation, but no visual indicator is shown to the user.
+**Action:** When hiding native inputs for custom styling, always apply a `:focus-visible` ring on the custom surrogate element using the adjacent sibling combinator (e.g., `input:focus-visible + .slider`).
+
+## 2023-10-24 - Make filter group headers keyboard accessible
+**Learning:** Adding `tabindex="0"` and `role="button"` makes custom group headers keyboard focusable, but requires an explicit `keydown` listener for 'Enter' and 'Space'. The default 'Space' behavior scrolls the page, requiring `e.preventDefault()`. Custom focus outlines via `:focus-visible` can cause layout shifts if not balanced with equal positive padding and negative margin (e.g., `padding: 2px 4px; margin: -2px -4px;`).
+**Action:** When implementing custom toggle elements, always add the `keydown` event listener, suppress default spacebar scrolling, and use the padding/margin trick to safely add focus rings without breaking the layout.
+
+## 2026-05-06 - Programmatic Checkbox Toggling
+**Learning:** When programmatically toggling the `checked` property of a native `<input type="checkbox">` in a custom `keydown` event listener (e.g., to handle 'Space' or 'Enter'), the browser does not automatically fire a 'change' event like it does for a physical click. This breaks any downstream logic relying on 'change' listeners.
+**Action:** Always explicitly dispatch a new 'change' event (e.g., `element.dispatchEvent(new Event('change'))`) immediately after programmatically mutating the `checked` state to ensure complete functionality parity with native clicks.
+
+## 2026-05-15 - Destructive Actions and Confirmation
+**Learning:** Destructive actions without confirmation dialogs can easily lead to accidental data loss and frustration. Users often click quickly and don't realize the consequences of their action until it's too late.
+**Action:** Always wrap destructive actions, such as deleting a feature in a map editor, with a confirmation dialog (e.g., `window.confirm`) to explicitly require user consent and prevent accidental data loss. Furthermore, make the prompt contextual by including the feature name to reduce ambiguity.

--- a/js/map-editor.js
+++ b/js/map-editor.js
@@ -1092,7 +1092,9 @@
 
     function deleteSelectedFeature() {
         if (!state.selectedFeature) return;
-        if (!window.confirm('Are you sure you want to delete this feature?')) return;
+        const feature = getSelectedFeature();
+        const label = feature.name || feature.id || 'this feature';
+        if (!window.confirm(`Are you sure you want to delete ${label}?`)) return;
         const collection = getCurrentFeatureCollection(state.selectedFeature.mode);
         collection.splice(state.selectedFeature.index, 1);
         deselectFeature();


### PR DESCRIPTION
🎨 **Palette: Improve destructive action context**

💡 **What:**
Updated the delete confirmation prompt in the map editor (`js/map-editor.js`) to dynamically include the name (or ID) of the feature being deleted, falling back to "this feature" if neither is available.

🎯 **Why:**
Destructive actions are risky. A generic "Are you sure you want to delete this feature?" prompt forces the user to rely entirely on their short-term memory to verify what they have selected. By explicitly naming the feature in the prompt (e.g., "Are you sure you want to delete the Dragon's Lair?"), we significantly reduce cognitive load and the risk of accidental data loss. Good UX gives users confidence before they commit to permanent actions.

♿ **Accessibility:**
While primarily a general usability and error-prevention enhancement, clarifying confirmation dialogs helps all users, particularly those with cognitive disabilities or users navigating quickly with screen readers who might lose track of their current selection state.

---
*PR created automatically by Jules for task [12177291001846996377](https://jules.google.com/task/12177291001846996377) started by @jaxsnjohnson*