### PR TITLE
🛡️ Sentinel: [HIGH] Sanitize setHtml input to prevent XSS

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -18,3 +18,7 @@
 **Vulnerability:** XSS via `escapeForSingleQuotedAttribute` when the output is rendered using `innerHTML`. The function escaped backslashes and single quotes correctly for a JavaScript string context, but failed to escape HTML entities (like `&apos;`). When assigned to `innerHTML`, the browser decodes `&apos;` to `'` *before* evaluating the `onclick` attribute, breaking out of the single quotes and executing arbitrary code.
 **Learning:** When sanitizing strings that will be placed inside inline event handlers (like `onclick='...'`) and injected via `innerHTML`, the escaping must handle both JavaScript string boundaries *and* HTML entity decoding.
 **Prevention:** Always escape ampersands (`&`) to `&amp;` alongside quotes and backslashes to prevent HTML parsers from decoding entities prematurely when injecting attributes into the DOM via strings.
+## 2025-02-28 - Sanitize InnerHTML in configuration module
+**Vulnerability:** XSS vulnerability in `setHtml` within `js/app-config.js` due to blind assignment of `element.innerHTML = value`.
+**Learning:** Utilities that assign dynamic values to `innerHTML` must validate and sanitize the input, even if the data is assumed to come from a safe configuration source, to maintain defense-in-depth and prevent DOM-based XSS.
+**Prevention:** Always use `DOMPurify.sanitize()` when injecting untrusted or external HTML. Implement an inline `escapeHtml()` fallback when `DOMPurify` is conditionally loaded to ensure a "fail-closed" security posture.

--- a/js/app-config.js
+++ b/js/app-config.js
@@ -483,7 +483,11 @@ const COLOR_LIKE_PATTERN = /^(#[0-9a-f]{3,8}|rgba?\([^)]+\)|hsla?\([^)]+\)|[a-z]
 
     function setHtml(documentRef, selector, value) {
         const element = documentRef && documentRef.querySelector(selector);
-        if (element && value !== undefined) element.innerHTML = value;
+        if (element && value !== undefined) {
+            element.innerHTML = typeof DOMPurify !== 'undefined'
+                ? DOMPurify.sanitize(value)
+                : escapeHtml(value);
+        }
     }
 
     function hydrateBottomLinks(documentRef) {


### PR DESCRIPTION
Updated `setHtml` in `js/app-config.js` to securely sanitize HTML input using `DOMPurify` or an `escapeHtml` fallback to prevent DOM-based XSS vulnerabilities.

---
*PR created automatically by Jules for task [13255909424610629750](https://jules.google.com/task/13255909424610629750) started by @jaxsnjohnson*