### PR TITLE
🧪 [testing improvement] Add test coverage for buildPopupMainContainer

### DIFF
--- a/tests/buildPopupMainContainer.test.js
+++ b/tests/buildPopupMainContainer.test.js
@@ -1,0 +1,52 @@
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+
+(function() {
+    const appSource = fs.readFileSync('js/app.js', 'utf8');
+
+    const buildStart = appSource.indexOf('function buildPopupMainContainer(safeSummary, fullContentInnerHtml, hasSummary, hasFullContent) {');
+    const buildEnd = appSource.indexOf('// --- Auto-generate a reverse map for quick lookup (Type -> Group) ---');
+
+    if (buildStart === -1 || buildEnd === -1) {
+        throw new Error('Could not locate buildPopupMainContainer in js/app.js');
+    }
+
+    const buildSource = appSource.slice(buildStart, buildEnd);
+
+    // eslint-disable-next-line no-eval
+    eval(buildSource);
+
+    // test case 1: hasSummary = true, hasFullContent = true
+    let result = buildPopupMainContainer('A safe summary', '<p>Full content</p>', true, true);
+    assert.ok(result.mainContent.includes('<div class="popup-summary">'), 'Should contain summary container');
+    assert.ok(result.mainContent.includes('<p>A safe summary</p>'), 'Should contain safe summary');
+    assert.ok(result.mainContent.includes('<div class="popup-full-content">'), 'Should contain full content container');
+    assert.ok(result.mainContent.includes('<p>Full content</p>'), 'Should contain full content inner HTML');
+    assert.ok(result.readMoreButton.includes('<div class="popup-read-more" onclick="togglePopupExpand(this)">Read More</div>'), 'Should contain read more button');
+
+    // test case 2: hasSummary = true, hasFullContent = false
+    result = buildPopupMainContainer('A safe summary', '<p>Full content</p>', true, false);
+    assert.ok(result.mainContent.includes('<div class="popup-summary">'), 'Should contain summary container');
+    assert.ok(result.mainContent.includes('<p>A safe summary</p>'), 'Should contain safe summary');
+    assert.ok(result.mainContent.includes('<div class="popup-full-content">'), 'Should contain full content container');
+    assert.ok(result.mainContent.includes('<p>Full content</p>'), 'Should contain full content inner HTML');
+    assert.equal(result.readMoreButton, '', 'Read more button should be empty');
+
+    // test case 3: hasSummary = false, hasFullContent = true
+    result = buildPopupMainContainer('A safe summary', '<p>Full content</p>', false, true);
+    assert.ok(!result.mainContent.includes('<div class="popup-summary">'), 'Should NOT contain summary container');
+    assert.ok(!result.mainContent.includes('<p>A safe summary</p>'), 'Should NOT contain safe summary');
+    assert.ok(!result.mainContent.includes('<div class="popup-full-content">'), 'Should NOT contain full content container');
+    assert.ok(result.mainContent.includes('<p>Full content</p>'), 'Should contain full content inner HTML');
+    assert.ok(result.readMoreButton.includes('<div class="popup-read-more" onclick="togglePopupExpand(this)">Read More</div>'), 'Should contain read more button');
+
+    // test case 4: hasSummary = false, hasFullContent = false
+    result = buildPopupMainContainer('A safe summary', '<p>Full content</p>', false, false);
+    assert.ok(!result.mainContent.includes('<div class="popup-summary">'), 'Should NOT contain summary container');
+    assert.ok(!result.mainContent.includes('<p>A safe summary</p>'), 'Should NOT contain safe summary');
+    assert.ok(!result.mainContent.includes('<div class="popup-full-content">'), 'Should NOT contain full content container');
+    assert.ok(result.mainContent.includes('<p>Full content</p>'), 'Should contain full content inner HTML');
+    assert.equal(result.readMoreButton, '', 'Read more button should be empty');
+
+    console.log('buildPopupMainContainer tests passed');
+})();


### PR DESCRIPTION
🎯 **What:** The testing gap addressed is the lack of unit tests for `buildPopupMainContainer` located in `js/app.js:558`.

📊 **Coverage:** All four scenarios are now tested combinations:
- `hasSummary = true`, `hasFullContent = true`
- `hasSummary = true`, `hasFullContent = false`
- `hasSummary = false`, `hasFullContent = true`
- `hasSummary = false`, `hasFullContent = false`

✨ **Result:** The improvement in test coverage allows us to ensure that the layout structure of standard and read-more popups remains deterministic when modifying HTML layout strings.

---
*PR created automatically by Jules for task [11397436918229304402](https://jules.google.com/task/11397436918229304402) started by @jaxsnjohnson*