### PR TITLE
🧪 Add tests for refreshLucideIcons

### DIFF
--- a/tests/refreshLucideIcons.test.js
+++ b/tests/refreshLucideIcons.test.js
@@ -1,0 +1,45 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'bun:test';
+
+const fs = require('fs');
+const appSource = fs.readFileSync(__dirname + '/../js/app.js', 'utf8');
+
+// Extract the refreshLucideIcons function logic
+const startIndex = appSource.indexOf('function refreshLucideIcons() {');
+const nextFunctionIndex = appSource.indexOf('// --- Measurement Tool State ---', startIndex);
+const functionString = appSource.substring(startIndex, nextFunctionIndex);
+
+let refreshLucideIcons;
+eval(`refreshLucideIcons = ${functionString}`);
+
+describe('refreshLucideIcons', () => {
+    beforeEach(() => {
+        global.window = {};
+    });
+
+    afterEach(() => {
+        delete global.window;
+    });
+
+    it('should not throw an error if window.lucide is undefined', () => {
+        expect(() => refreshLucideIcons()).not.toThrow();
+    });
+
+    it('should not throw an error if window.lucide is defined but createIcons is not a function', () => {
+        global.window.lucide = {};
+        expect(() => refreshLucideIcons()).not.toThrow();
+
+        global.window.lucide.createIcons = 'not a function';
+        expect(() => refreshLucideIcons()).not.toThrow();
+    });
+
+    it('should call window.lucide.createIcons if it is a function', () => {
+        const createIconsMock = vi.fn();
+        global.window.lucide = {
+            createIcons: createIconsMock
+        };
+
+        refreshLucideIcons();
+
+        expect(createIconsMock).toHaveBeenCalled();
+    });
+});


### PR DESCRIPTION
🎯 **What:** Added tests for the `refreshLucideIcons` function in `js/app.js`, which lacked coverage.
📊 **Coverage:** The new tests cover:
- Edge case: `window.lucide` is undefined
- Edge case: `window.lucide.createIcons` is defined but not a function
- Happy path: `window.lucide.createIcons` is a valid function and gets called successfully
✨ **Result:** Improved test coverage and reliability for icon rendering fallback logic.

---
*PR created automatically by Jules for task [13492128645696074818](https://jules.google.com/task/13492128645696074818) started by @jaxsnjohnson*