### PR TITLE
🧪 Add tests for getMobileLayoutModeFromUrl

### DIFF
--- a/tests/getMobileLayoutModeFromUrl.test.js
+++ b/tests/getMobileLayoutModeFromUrl.test.js
@@ -1,0 +1,69 @@
+import { describe, it, expect, beforeEach, afterEach } from 'bun:test';
+import fs from 'node:fs';
+
+const appSource = fs.readFileSync('js/app.js', 'utf8');
+
+const normalizeStart = appSource.indexOf('function normalizeMobileLayoutMode(');
+const normalizeEnd = appSource.indexOf('function getMobileLayoutModeFromUrl()', normalizeStart);
+const normalizeSource = appSource.slice(normalizeStart, normalizeEnd);
+
+const getUrlParamsStart = appSource.indexOf('function getUrlParameters() {');
+const getUrlParamsEnd = appSource.indexOf('function isEmbedModeFromUrl()', getUrlParamsStart);
+const getUrlParamsSource = appSource.slice(getUrlParamsStart, getUrlParamsEnd);
+
+const getModeStart = appSource.indexOf('function getMobileLayoutModeFromUrl() {');
+const getModeEnd = appSource.indexOf('function resolveMobileLayoutV2Enabled()', getModeStart);
+const getModeSource = appSource.slice(getModeStart, getModeEnd);
+
+let getMobileLayoutModeFromUrlRef;
+
+(() => {
+    global.MOBILE_LAYOUT_MODE_V2 = 'v2';
+    global.MOBILE_LAYOUT_MODE_LEGACY = 'legacy';
+    global.MOBILE_LAYOUT_QUERY_PARAM = 'mobileLayout';
+
+    eval(`
+        ${normalizeSource}
+        ${getUrlParamsSource}
+        ${getModeSource}
+        getMobileLayoutModeFromUrlRef = getMobileLayoutModeFromUrl;
+    `);
+})();
+
+describe('getMobileLayoutModeFromUrl', () => {
+    const originalWindow = global.window;
+
+    afterEach(() => {
+        global.window = originalWindow;
+    });
+
+    it('returns "v2" when mobileLayout=v2', () => {
+        global.window = { location: { search: '?mobileLayout=v2' } };
+        expect(getMobileLayoutModeFromUrlRef()).toBe('v2');
+    });
+
+    it('returns "legacy" when mobileLayout=legacy', () => {
+        global.window = { location: { search: '?mobileLayout=legacy' } };
+        expect(getMobileLayoutModeFromUrlRef()).toBe('legacy');
+    });
+
+    it('returns null when mobileLayout is invalid', () => {
+        global.window = { location: { search: '?mobileLayout=invalid' } };
+        expect(getMobileLayoutModeFromUrlRef()).toBeNull();
+    });
+
+    it('returns null when mobileLayout is missing', () => {
+        global.window = { location: { search: '?otherParam=123' } };
+        expect(getMobileLayoutModeFromUrlRef()).toBeNull();
+    });
+
+    it('returns null when search is empty', () => {
+        global.window = { location: { search: '' } };
+        expect(getMobileLayoutModeFromUrlRef()).toBeNull();
+    });
+
+    it('returns "v2" ignoring case and whitespace', () => {
+        global.window = { location: { search: '?mobileLayout=%20V2%20' } };
+        expect(getMobileLayoutModeFromUrlRef()).toBe('v2');
+    });
+});


### PR DESCRIPTION
🎯 **What:** The testing gap addressed is the lack of unit tests for the `getMobileLayoutModeFromUrl` function inside `js/app.js`.
📊 **Coverage:** The new test file (`tests/getMobileLayoutModeFromUrl.test.js`) covers scenarios where the `mobileLayout` query parameter is 'v2', 'legacy', invalid, missing, empty, and includes extra whitespace/casing differences.
✨ **Result:** The improvement in test coverage ensures that future refactoring of mobile layout parsing logic will have a robust safety net to catch regressions without executing the entire application script.

---
*PR created automatically by Jules for task [18034639287289536777](https://jules.google.com/task/18034639287289536777) started by @jaxsnjohnson*