### PR TITLE
fix: remove actionable prefix from historical security fix comment

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -1454,7 +1454,7 @@ function renderMapBlurbContent(mapInfo = getMapRuntimeData(currentlyLoadedMapId)
     const safeName = escapeHtml(mapInfo?.name || 'Atlas');
     const defaultCopy = '<p>Open the guide for controls, shortcuts, and atlas help.</p>';
 
-    // Security Fix: Sanitize HTML content containing map blurbs before inserting it into the DOM
+    // Sanitize HTML content containing map blurbs before inserting it into the DOM
     // to prevent Stored XSS via malicious injected tags or event handlers.
     // If DOMPurify fails to load, we fail closed by escaping the HTML to prevent XSS.
     const blurbBody = typeof DOMPurify !== 'undefined'


### PR DESCRIPTION
Removed the "Security Fix:" prefix from a comment in `js/app.js` that was documenting an already-implemented HTML sanitization measure. This prevents the comment from being incorrectly flagged as a pending task by automated parsers. No functional changes were made.

---
*PR created automatically by Jules for task [1743773513358381405](https://jules.google.com/task/1743773513358381405) started by @jaxsnjohnson*