### PR TITLE
Fix false positive security scanner issue by removing 'Security fix:' prefix

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -1865,7 +1865,7 @@ function getMapChooserDescriptionText(mapInfo) {
     ).trim();
     if (!rawText) return '';
 
-    // Security fix: Uses DOMParser instead of innerHTML to prevent execution of embedded scripts
+    // Uses DOMParser instead of innerHTML to prevent execution of embedded scripts
     // or loading of external resources (like <img src=x onerror=...>) when stripping HTML.
     const parser = new DOMParser();
     const sandbox = parser.parseFromString(rawText, 'text/html');

--- a/tests/getMapChooserDescriptionText.test.js
+++ b/tests/getMapChooserDescriptionText.test.js
@@ -1,0 +1,56 @@
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+
+const appSource = fs.readFileSync('js/app.js', 'utf8');
+
+const fnStart = appSource.indexOf('function getMapChooserDescriptionText(mapInfo) {');
+const fnEnd = appSource.indexOf('async function hydrateMapChooserCard(card, mapInfo) {');
+
+if (fnStart === -1 || fnEnd === -1 || fnEnd <= fnStart) {
+    throw new Error('Could not locate getMapChooserDescriptionText in js/app.js');
+}
+
+const fnSource = appSource.slice(fnStart, fnEnd);
+
+// Wrap the test in an IIFE as per project memory
+(function() {
+    // Mock DOMParser
+    class DOMParserMock {
+        parseFromString(str, type) {
+            // A simple mock for extracting text content from HTML tags
+            const stripped = str.replace(/<[^>]*>/g, '');
+            return {
+                body: {
+                    textContent: stripped,
+                    innerText: stripped
+                }
+            };
+        }
+    }
+    const origDOMParser = global.DOMParser;
+    global.DOMParser = DOMParserMock;
+
+    let getMapChooserDescriptionText;
+    // eslint-disable-next-line no-eval
+    eval(`getMapChooserDescriptionText = ${fnSource}`);
+
+    // Test 1: returns empty string for missing or empty input
+    assert.equal(getMapChooserDescriptionText(null), '');
+    assert.equal(getMapChooserDescriptionText({}), '');
+    assert.equal(getMapChooserDescriptionText({ selectorDescription: '  ' }), '');
+
+    // Test 2: prioritizes fields correctly
+    assert.equal(getMapChooserDescriptionText({ selectorDescription: 'A', summary: 'B' }), 'A');
+    assert.equal(getMapChooserDescriptionText({ summary: 'B', description: 'C' }), 'B');
+    assert.equal(getMapChooserDescriptionText({ description: 'C', blurb: 'D' }), 'C');
+    assert.equal(getMapChooserDescriptionText({ blurb: 'D' }), 'D');
+
+    // Test 3: parses HTML using DOMParser mock and returns text content
+    assert.equal(getMapChooserDescriptionText({ summary: '<b>Bold</b> text' }), 'Bold text');
+    assert.equal(getMapChooserDescriptionText({ summary: 'Look at this <img src="x" onerror="alert(1)"> image' }), 'Look at this  image');
+
+    // Restore globals
+    global.DOMParser = origDOMParser;
+})();
+
+console.log('getMapChooserDescriptionText unit tests passed');


### PR DESCRIPTION
Removed 'Security fix:' prefix from `DOMParser` comment in `js/app.js` to prevent automated issue scanners from flagging it as a pending vulnerability or actionable TODO.

Additionally, created `tests/getMapChooserDescriptionText.test.js` using a mocked `DOMParser` to provide formal unit test coverage for the HTML stripping functionality.

---
*PR created automatically by Jules for task [9785432727814960030](https://jules.google.com/task/9785432727814960030) started by @jaxsnjohnson*