### PR TITLE
🔒 [security fix] Fix XSS via DOMPurify fallback using backticks

### DIFF
--- a/js/app-config.js
+++ b/js/app-config.js
@@ -271,7 +271,8 @@
             .replace(/</g, '&lt;')
             .replace(/>/g, '&gt;')
             .replace(/"/g, '&quot;')
-            .replace(/'/g, '&#39;');
+            .replace(/'/g, '&#39;')
+            .replace(/`/g, '&#96;');
     }
 
 const COLOR_LIKE_PATTERN = /^(#[0-9a-f]{3,8}|rgba?\([^)]+\)|hsla?\([^)]+\)|[a-z]+|var\(--[a-z0-9_-]+\)|transparent|white|black)$/i;

--- a/js/app.js
+++ b/js/app.js
@@ -286,7 +286,8 @@ function escapeHtml(value) {
         .replace(/</g, '&lt;')
         .replace(/>/g, '&gt;')
         .replace(/"/g, '&quot;')
-        .replace(/'/g, '&#39;');
+        .replace(/'/g, '&#39;')
+        .replace(/`/g, '&#96;');
 }
 
 function escapeForSingleQuotedAttribute(value) {

--- a/js/map-editor.js
+++ b/js/map-editor.js
@@ -115,7 +115,8 @@
             .replace(/</g, '&lt;')
             .replace(/>/g, '&gt;')
             .replace(/"/g, '&quot;')
-            .replace(/'/g, '&#39;');
+            .replace(/'/g, '&#39;')
+            .replace(/`/g, '&#96;');
     }
 
     function getCurrentPoints() {

--- a/tests/escapeHtml.test.js
+++ b/tests/escapeHtml.test.js
@@ -48,10 +48,11 @@ const fs = require('node:fs');
     assert.equal(escapeHtml('>'), '&gt;');
     assert.equal(escapeHtml('"'), '&quot;');
     assert.equal(escapeHtml("'"), '&#39;');
+    assert.equal(escapeHtml('`'), '&#96;');
 
     // Test combinations
     assert.equal(escapeHtml('<script>alert("XSS & hacks")</script>'), '&lt;script&gt;alert(&quot;XSS &amp; hacks&quot;)&lt;/script&gt;');
-    assert.equal(escapeHtml('user\'s "data" & info < >'), 'user&#39;s &quot;data&quot; &amp; info &lt; &gt;');
+    assert.equal(escapeHtml('user\'s "data" & info < > `template`'), 'user&#39;s &quot;data&quot; &amp; info &lt; &gt; &#96;template&#96;');
 
     console.log('escapeHtml regression checks passed');
 })();


### PR DESCRIPTION
🎯 **What:** The `escapeHtml` utility function used as a fallback for `DOMPurify` lacked sanitization for the single backtick character (`` ` ``).

⚠️ **Risk:** If an attacker crafted a malicious payload using backticks, it could potentially break out of attribute boundaries in legacy browsers or execute template literal injection attacks if the output was later evaluated as JavaScript. Because `escapeHtml` is used to sanitize critical user data (like map blurbs) when `DOMPurify` fails to load or is not conditionally executed, this poses a Stored XSS risk.

🛡️ **Solution:** Updated the `escapeHtml` functions in `js/app.js`, `js/app-config.js`, and `js/map-editor.js` to escape the single backtick character to `&#96;`. Also added a regression test in `tests/escapeHtml.test.js` to assert the new escape logic.

---
*PR created automatically by Jules for task [17937693581360903889](https://jules.google.com/task/17937693581360903889) started by @jaxsnjohnson*