### PR TITLE
🔒 Fix potential DOM-based XSS in app-config WIP notice

### DIFF
--- a/js/app-config.js
+++ b/js/app-config.js
@@ -555,11 +555,12 @@ const COLOR_LIKE_PATTERN = /^(#[0-9a-f]{3,8}|rgba?\([^)]+\)|hsla?\([^)]+\)|[a-z]
         const wipPopup = documentRef.getElementById('wip-popup');
         const notices = get('copy.wipNotice', []);
         if (wipPopup && Array.isArray(notices)) {
-            const safeNotices = notices.map((line) => {
-                const strLine = String(line);
-                return `<p>${typeof DOMPurify !== 'undefined' ? DOMPurify.sanitize(strLine) : escapeHtml(strLine)}</p>`;
-            }).join('');
-            wipPopup.innerHTML = safeNotices;
+            wipPopup.innerHTML = '';
+            notices.forEach((line) => {
+                const p = documentRef.createElement('p');
+                p.textContent = String(line);
+                wipPopup.appendChild(p);
+            });
             wipPopup.hidden = !get('features.wipNotice', true);
         }
 


### PR DESCRIPTION
🎯 What:
Fixed a potential DOM-based XSS vulnerability when rendering the `wipNotice` configuration array in `js/app-config.js`. The logic previously utilized `.innerHTML` and relied on `DOMPurify` (or an `escapeHtml` fallback if `DOMPurify` wasn't loaded) to sanitize the injected lines.

⚠️ Risk:
While `escapeHtml` covers the basic HTML entities, directly assigning string concatenations into `.innerHTML` when there's an opportunity to bypass full parsing or when dynamic content is introduced presents an underlying DOM-based XSS risk, particularly if configurations are modified.

🛡️ Solution:
Refactored the `wipPopup` content generation to explicitly iterate over `notices`, manually instantiate `<p>` DOM nodes using `documentRef.createElement('p')`, and assign the values via the `.textContent` property. This approach completely eradicates the possibility of executing XSS payloads, as the browser treats `.textContent` purely as text, regardless of the characters inside.

---
*PR created automatically by Jules for task [5432113444020216551](https://jules.google.com/task/5432113444020216551) started by @jaxsnjohnson*