### PR TITLE
🧹 Extract duplicated fetchJsonAsset into a shared utilities module

### DIFF
--- a/index.html
+++ b/index.html
@@ -455,8 +455,8 @@
                     }, { once: true });
                 }
                 const scripts = window.AppConfig
-                    ? window.AppConfig.get("assets.scripts", ["js/libs/Control.MiniMap.min.js", "js/starfield.js", "js/app.js"])
-                    : ["js/libs/Control.MiniMap.min.js", "js/starfield.js", "js/app.js"];
+                    ? window.AppConfig.get("assets.scripts", ["js/libs/Control.MiniMap.min.js", "js/starfield.js", "js/shared-utils.js", "js/app.js"])
+                    : ["js/libs/Control.MiniMap.min.js", "js/starfield.js", "js/shared-utils.js", "js/app.js"];
                 const appendNext = (index) => {
                     if (index >= scripts.length) return;
                     appendScript(scripts[index], () => appendNext(index + 1));

--- a/js/app-config.js
+++ b/js/app-config.js
@@ -29,10 +29,12 @@
                 scripts: [
                     'js/libs/Control.MiniMap.min.js',
                     'js/starfield.js',
+                    'js/shared-utils.js',
                     'js/app.js'
                 ],
                 editorScripts: [
                     'js/editor-shared.js',
+                    'js/shared-utils.js',
                     'js/map-editor.js'
                 ],
                 cloudTexture: 'images/clouds.webp',

--- a/js/app.js
+++ b/js/app.js
@@ -1,5 +1,6 @@
 // --- Global Variables ---
 const APP_CONFIG = typeof window !== 'undefined' && window.AppConfig ? window.AppConfig : null;
+const { withAssetVersion, fetchJsonAsset } = typeof window !== 'undefined' && window.SharedUtils ? window.SharedUtils : {};
 const getConfigValue = (path, fallbackValue) => APP_CONFIG ? APP_CONFIG.get(path, fallbackValue) : fallbackValue;
 const getFeatureFlag = (name, fallbackValue = true) => getConfigValue(`features.${name}`, fallbackValue) !== false;
 const getPerformanceNumber = (name, fallbackValue) => {
@@ -1969,12 +1970,6 @@ function openMapFromChooser(mapInfo) {
     navigateToMap(mapInfo.id, { preResolvedMap: mapInfo });
 }
 
-function withAssetVersion(url) {
-    const version = encodeURIComponent(window.APP_ASSET_VERSION || '0');
-    const separator = String(url).includes('?') ? '&' : '?';
-    return `${url}${separator}v=${version}`;
-}
-
 function isValidThemePreference(value) {
     return value === 'light' || value === 'dark' || value === 'system';
 }
@@ -2401,14 +2396,6 @@ function getMapDataUrl(mapEntry) {
     if (explicitUrl) return explicitUrl;
     const mapId = String(mapEntry?.id || '').trim();
     return mapId ? `maps/${mapId}.json` : '';
-}
-
-async function fetchJsonAsset(url) {
-    const response = await fetch(withAssetVersion(url));
-    if (!response.ok) {
-        throw new Error(`Failed to load ${url}: ${response.status} ${response.statusText}`);
-    }
-    return response.json();
 }
 
 async function getMapDefinition(mapId, preResolvedMap = null) {

--- a/js/map-editor.js
+++ b/js/map-editor.js
@@ -1,7 +1,8 @@
 (function () {
     const utils = window.MapEditorUtils;
+    const sharedUtils = window.SharedUtils;
 
-    if (!utils || typeof L === 'undefined') {
+    if (!utils || !sharedUtils || typeof L === 'undefined') {
         console.error('Map editor prerequisites are missing.');
         return;
     }
@@ -142,14 +143,7 @@
         return state.currentMap[state.lineCollectionKey];
     }
 
-    function fetchJsonAsset(url) {
-        return fetch(url).then((response) => {
-            if (!response.ok) {
-                throw new Error(`Failed to load ${url}: ${response.status} ${response.statusText}`);
-            }
-            return response.json();
-        });
-    }
+    const fetchJsonAsset = sharedUtils.fetchJsonAsset;
 
     function findNodeLocation(items, id, parentId = '') {
         if (!Array.isArray(items)) return null;

--- a/js/shared-utils.js
+++ b/js/shared-utils.js
@@ -1,0 +1,28 @@
+(function (root, factory) {
+    if (typeof module === 'object' && module.exports) {
+        module.exports = factory();
+        return;
+    }
+    root.SharedUtils = factory();
+}(typeof globalThis !== 'undefined' ? globalThis : this, function () {
+    function withAssetVersion(url) {
+        const version = typeof window !== 'undefined' && window.APP_ASSET_VERSION
+            ? encodeURIComponent(window.APP_ASSET_VERSION)
+            : '0';
+        const separator = String(url).includes('?') ? '&' : '?';
+        return `${url}${separator}v=${version}`;
+    }
+
+    async function fetchJsonAsset(url) {
+        const response = await fetch(withAssetVersion(url));
+        if (!response.ok) {
+            throw new Error(`Failed to load ${url}: ${response.status} ${response.statusText}`);
+        }
+        return response.json();
+    }
+
+    return {
+        withAssetVersion,
+        fetchJsonAsset
+    };
+}));

--- a/map-editor.html
+++ b/map-editor.html
@@ -202,8 +202,8 @@
                 if (window.AppConfig) window.AppConfig.hydrateEditorDom(document);
                 const version = encodeURIComponent(window.APP_ASSET_VERSION || "0");
                 const scripts = window.AppConfig
-                    ? window.AppConfig.get("assets.editorScripts", ["js/editor-shared.js", "js/map-editor.js"])
-                    : ["js/editor-shared.js", "js/map-editor.js"];
+                    ? window.AppConfig.get("assets.editorScripts", ["js/editor-shared.js", "js/shared-utils.js", "js/map-editor.js"])
+                    : ["js/editor-shared.js", "js/shared-utils.js", "js/map-editor.js"];
                 scripts.forEach((src) => {
                 const script = document.createElement("script");
                 script.src = `${src}?v=${version}`;


### PR DESCRIPTION
🎯 **What:** The code health issue addressed
Created a new shared utility module `js/shared-utils.js` utilizing the repository's standard UMD pattern to house the `fetchJsonAsset` and `withAssetVersion` functions. Both `js/app.js` and `js/map-editor.js` were updated to remove their duplicate implementations and reference the single source of truth.

💡 **Why:** How this improves maintainability
Extracting `fetchJsonAsset` and `withAssetVersion` deduplicates code and ensures a consistent asset-fetching mechanism. Crucially, the map editor will now correctly apply cache-busting behavior (`withAssetVersion`) when fetching JSON maps, standardizing the application logic across environments.

✅ **Verification:** How you confirmed the change is safe
Ran the full Node `bun test tests/` test suite and verified 100% of the regression test cases passed successfully. Validated changes to HTML script arrays locally.

✨ **Result:** The improvement achieved
A single shared implementation for JSON fetching logic that guarantees future enhancements (e.g. error handling, logging, caching) will transparently benefit both the main Atlas viewer and the internal Map Editor alike.

---
*PR created automatically by Jules for task [7058499608584799760](https://jules.google.com/task/7058499608584799760) started by @jaxsnjohnson*