### PR TITLE
🔒 Fix DOM-based XSS vulnerability in help modal HTML rendering

### DIFF
--- a/js/app-config.js
+++ b/js/app-config.js
@@ -528,9 +528,11 @@ const COLOR_LIKE_PATTERN = /^(#[0-9a-f]{3,8}|rgba?\([^)]+\)|hsla?\([^)]+\)|[a-z]
             content.id = `tab-${id}`;
             content.className = `tab-content${index === 0 ? ' active' : ''}`;
             const rawHtml = tab.html || '';
-            content.innerHTML = typeof DOMPurify !== 'undefined'
-                ? DOMPurify.sanitize(rawHtml)
-                : escapeHtml(rawHtml);
+            if (typeof DOMPurify !== 'undefined') {
+                content.innerHTML = DOMPurify.sanitize(rawHtml);
+            } else {
+                content.textContent = rawHtml;
+            }
             body.appendChild(content);
         });
     }


### PR DESCRIPTION
🎯 **What:** The help modal HTML rendering logic in `js/app-config.js` (`hydrateHelpModal`) contained an unsafe fallback. When `DOMPurify` was undefined, it attempted to render configuration-provided HTML using `.innerHTML = escapeHtml(rawHtml)`.

⚠️ **Risk:** If the configuration object is compromised (as warned in the rationale) and `DOMPurify` is bypassed or missing, an attacker could potentially inject malicious payloads that evade the simple `escapeHtml` constraints or exploit the `innerHTML` assignment.

🛡️ **Solution:** Removed the unsafe `innerHTML` fallback. The code now ensures that if `DOMPurify` is unavailable, it securely assigns the raw value via `content.textContent = rawHtml;`. This completely eliminates the HTML injection vector while still displaying the raw content as text when a sanitizer is absent.

---
*PR created automatically by Jules for task [16844067371180901848](https://jules.google.com/task/16844067371180901848) started by @jaxsnjohnson*