### PR TITLE
🎨 Palette: Add focus-visible states to select and textarea elements

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -23,3 +23,6 @@
 ## 2026-05-15 - Destructive Actions and Confirmation
 **Learning:** Destructive actions without confirmation dialogs can easily lead to accidental data loss and frustration. Users often click quickly and don't realize the consequences of their action until it's too late.
 **Action:** Always wrap destructive actions, such as deleting a feature in a map editor, with a confirmation dialog (e.g., `window.confirm`) to explicitly require user consent and prevent accidental data loss.
+## 2023-10-27 - Form Element Focus States
+**Learning:** By default, standard form elements like `<select>` and `<textarea>` might not automatically inherit the custom `:focus-visible` styling applied to `<input>` elements in global CSS resets, leaving them without clear visual indicators during keyboard navigation.
+**Action:** Always verify that all interactive form elements (`input`, `select`, `textarea`, `button`) are explicitly included in the comma-separated CSS selectors for `:focus-visible` styling to maintain consistent keyboard accessibility.

--- a/css/style.css
+++ b/css/style.css
@@ -522,6 +522,8 @@ body.map-chooser-open #share-relay-coachmark {
 a:focus-visible,
 button:focus-visible,
 input:focus-visible,
+select:focus-visible,
+textarea:focus-visible,
 .map-item:focus-visible,
 .folder-toggle-btn:focus-visible,
 .folder-main-action:focus-visible,


### PR DESCRIPTION
💡 What: Added `:focus-visible` states to `<select>` and `<textarea>` elements globally in `css/style.css`.
🎯 Why: To ensure consistent visual feedback across all interactive form elements during keyboard navigation.
📸 Before/After: Before, navigating via keyboard to select elements or textareas did not display a visible focus ring, making it difficult to track focus. After, they share the exact same blue outline focus ring as standard text inputs.
♿ Accessibility: Dramatically improves keyboard navigation experience and WCAG compliance by providing clear, visible focus indicators for standard form inputs.

---
*PR created automatically by Jules for task [11471160789338965464](https://jules.google.com/task/11471160789338965464) started by @jaxsnjohnson*