### PR TITLE
⚡ Bolt: precompute atlas search text

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,3 +1,7 @@
+## 2026-05-26 - Precompute Atlas Search Content
+**Learning:** The atlas index loader already normalized names, but atlas search still routed entries through generic matching that rebuilt and normalized secondary text (`mapName`, `typeLabel`, `summary`, `description`) for every visible entry on each query. On the current 300-entry atlas index, precomputed content matching was about 47% faster in repeated search benchmarks with about 162 KB of extra normalized text.
+**Action:** When atlas/search-index data is immutable after load, precompute both primary and secondary normalized fields during hydration and use `computePrecomputedSearchMatch` in hot search loops; keep `computeSearchMatch` for dynamic or unprepared data.
+
 ## 2024-05-20 - [Cache live HTMLCollection for O(1) iteration]
 **Learning:** Live `HTMLCollection`s (like those returned by `getElementsByTagName`) trigger an O(N) recalculation of the collection every time their `.length` or elements are accessed. When iterated over in performance-sensitive logic (such as UI filtering loops in `app.js`), this causes significant performance degradation.
 **Action:** When iterating over a live `HTMLCollection`, cache the collection into a static array using `Array.from()` immediately before the loop. This changes element access inside the loop from O(N) to O(1) and removes the live recalculation penalty.

--- a/js/app.js
+++ b/js/app.js
@@ -3627,19 +3627,16 @@ function searchMapRoutes(searchTerm, results, searchFiltersCurrentMap) {
 
 function searchAtlasIndex(searchTerm, results) {
     if (currentSearchScope === SEARCH_SCOPE_ATLAS && searchTerm) {
-        let currentAtlasEntry = null;
-        const getAtlasSecondaryText = () => `${currentAtlasEntry.mapName || ''} ${currentAtlasEntry.typeLabel || ''} ${currentAtlasEntry.summary || ''} ${currentAtlasEntry.description || ''}`;
-
         for (let i = 0; i < atlasSearchIndex.length; i++) {
             const entry = atlasSearchIndex[i];
             if (!visibilityAllowed(entry)) continue;
 
-            currentAtlasEntry = entry;
-            // ⚡ Bolt: Use pre-normalized name if available, and use a shared function context to avoid closure allocation
-            const match = computeSearchMatch(
+            // Bolt: Atlas load precomputes these normalized strings so searches avoid
+            // rebuilding and lowercasing secondary details for every atlas entry.
+            const match = computePrecomputedSearchMatch(
                 searchTerm,
-                entry._normalizedName || entry.name,
-                getAtlasSecondaryText
+                entry._normalizedName ?? normalizeSearchValue(entry.name),
+                entry._normalizedSearchContent ?? normalizeSearchValue(`${entry.mapName || ''} ${entry.typeLabel || ''} ${entry.summary || ''} ${entry.description || ''}`)
             );
 
             if (!match.matched) continue;
@@ -7088,9 +7085,12 @@ async function loadMapData() {
         atlasSearchIndex = Array.isArray(atlas.searchIndex) ? atlas.searchIndex : [];
         atlasGeneratedAt = atlas.generatedAt || null;
 
-        // ⚡ Bolt: Pre-normalize atlas search index names to accelerate computeSearchMatch during searches
+        // Bolt: Pre-normalize atlas search fields once so atlas search can use
+        // computePrecomputedSearchMatch without per-entry string concatenation.
         for (let i = 0; i < atlasSearchIndex.length; i++) {
-            atlasSearchIndex[i]._normalizedName = normalizeSearchValue(atlasSearchIndex[i].name);
+            const entry = atlasSearchIndex[i];
+            entry._normalizedName = normalizeSearchValue(entry.name);
+            entry._normalizedSearchContent = normalizeSearchValue(`${entry.mapName || ''} ${entry.typeLabel || ''} ${entry.summary || ''} ${entry.description || ''}`);
         }
 
         if (loadingIndicator && loadingIndicator.querySelector('.progress-bar')) {

--- a/tests/computeSearchMatch.test.js
+++ b/tests/computeSearchMatch.test.js
@@ -30,7 +30,8 @@ function extractFunctionSource(name) {
 const snippets = [
     extractFunctionSource('normalizeSearchValue'),
     extractFunctionSource('getFuzzyMatchScore'),
-    extractFunctionSource('computeSearchMatch')
+    extractFunctionSource('computeSearchMatch'),
+    extractFunctionSource('computePrecomputedSearchMatch')
 ].join('\n');
 
 // eslint-disable-next-line no-eval
@@ -51,5 +52,21 @@ assert.ok(prefix.score > fuzzy.score);
 assert.ok(fuzzy.score > 0);
 assert.ok(content.score > 0);
 assert.equal(computeSearchMatch('zzz', 'Icebeach', '').matched, false);
+
+const precomputedPrimary = normalizeSearchValue('Icebeach');
+const precomputedSecondary = normalizeSearchValue('A cold harbor city');
+
+assert.deepEqual(
+    computePrecomputedSearchMatch('ice', precomputedPrimary, precomputedSecondary),
+    computeSearchMatch('ice', 'Icebeach', 'A cold harbor city')
+);
+assert.deepEqual(
+    computePrecomputedSearchMatch('harbor', precomputedPrimary, precomputedSecondary),
+    computeSearchMatch('harbor', 'Icebeach', 'A cold harbor city')
+);
+assert.deepEqual(
+    computePrecomputedSearchMatch('zzz', precomputedPrimary, precomputedSecondary),
+    computeSearchMatch('zzz', 'Icebeach', 'A cold harbor city')
+);
 
 console.log('computeSearchMatch regression checks passed');


### PR DESCRIPTION
## 💡 What
Precompute normalized atlas search content during atlas loading and use `computePrecomputedSearchMatch` in atlas-wide search.

## 🎯 Why
Atlas search already pre-normalized entry names, but still routed each entry through generic matching that rebuilt and normalized secondary text (`mapName`, `typeLabel`, `summary`, `description`) on every query. This removes that repeated string work from the hot loop.

## 📊 Impact
On the current `maps/atlas-index.json`, the benchmark covers 300 atlas entries across 1200 repeated searches. It reduced atlas matching time from `198.97ms` to `105.04ms`, a `47.2%` speedup, with identical match counts. The memory tradeoff is about `162KB` of normalized secondary text.

## 🔬 Measurement
- `node --test tests/computeSearchMatch.test.js tests/sortSearchResults.test.js` passed: 2 tests.
- `node --test $(rg --files-without-match "bun:test" tests/*.test.js)` passed: 90 tests.
- Atlas search benchmark: baseline `198.97ms`, optimized `105.04ms`, `matchedEqual: true`.

No package manager manifest is present in this repo, and `bun` is not installed in the local environment, so Bun-authored tests were not run locally.