### PR TITLE
🧪 Add test for setMeta

### DIFF
--- a/tests/setMeta.test.js
+++ b/tests/setMeta.test.js
@@ -1,0 +1,84 @@
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+
+(() => {
+    const appConfigSource = fs.readFileSync('js/app-config.js', 'utf8');
+
+    // Extract function using indexOf
+    const start = appConfigSource.indexOf('function setMeta(');
+    if (start === -1) throw new Error('Could not find function setMeta');
+
+    const end = appConfigSource.indexOf('function setIcon(', start);
+    if (end === -1) throw new Error('Could not find end of function setMeta');
+
+    const snippet = appConfigSource.slice(start, end);
+
+    // Evaluate the function
+    let setMeta;
+    // eslint-disable-next-line no-eval
+    eval(`setMeta = ${snippet}`);
+
+    // Mock document structure
+    function createMockDocument() {
+        const headChildren = [];
+        const elements = {}; // simulate elements by selector for querySelector
+
+        const mockHead = {
+            appendChild: (el) => headChildren.push(el)
+        };
+
+        const mockDocument = {
+            head: mockHead,
+            querySelector: (sel) => elements[sel] || null,
+            createElement: (tag) => {
+                const attributes = {};
+                return {
+                    tagName: tag,
+                    attributes,
+                    setAttribute: function(name, val) { this.attributes[name] = val; }
+                };
+            },
+            _setMockElement: (sel, el) => { elements[sel] = el; },
+            _getHeadChildren: () => headChildren
+        };
+
+        return mockDocument;
+    }
+
+    // Test 1: Undefined documentRef
+    assert.doesNotThrow(() => {
+        setMeta(undefined, 'meta[name="description"]', 'name', 'description', 'test');
+    });
+
+    // Test 2: Null documentRef
+    assert.doesNotThrow(() => {
+        setMeta(null, 'meta[name="description"]', 'name', 'description', 'test');
+    });
+
+    // Test 3: Element does not exist
+    let doc = createMockDocument();
+    setMeta(doc, 'meta[name="description"]', 'name', 'description', 'test content');
+
+    let children = doc._getHeadChildren();
+    assert.equal(children.length, 1, 'Should append one element to head');
+    assert.equal(children[0].tagName, 'meta', 'Should create a meta element');
+    assert.equal(children[0].attributes['name'], 'description', 'Should set attribute name=description');
+    assert.equal(children[0].attributes['content'], 'test content', 'Should set content attribute');
+
+    // Test 4: Element already exists
+    doc = createMockDocument();
+    const existingElement = {
+        attributes: { name: 'description', content: 'old content' },
+        setAttribute: function(name, val) { this.attributes[name] = val; }
+    };
+    doc._setMockElement('meta[name="description"]', existingElement);
+
+    setMeta(doc, 'meta[name="description"]', 'name', 'description', 'new content');
+
+    children = doc._getHeadChildren();
+    assert.equal(children.length, 0, 'Should not append a new element to head');
+    assert.equal(existingElement.attributes['name'], 'description', 'Original attribute should remain');
+    assert.equal(existingElement.attributes['content'], 'new content', 'Content attribute should be updated');
+
+    console.log('setMeta tests passed');
+})();


### PR DESCRIPTION
🎯 **What:** The `setMeta` function in `js/app-config.js` was previously untested. This function modifies document metadata and handles DOM manipulation side effects, making it an important candidate for test coverage.
📊 **Coverage:** A new test file `tests/setMeta.test.js` was added. It covers scenarios including an undefined/null `documentRef`, creation of a new `meta` element when it does not exist, and updating an existing `meta` element's `content` attribute.
✨ **Result:** Test coverage improved, and future regressions in document metadata handling will be caught reliably.

---
*PR created automatically by Jules for task [9058672822126895481](https://jules.google.com/task/9058672822126895481) started by @jaxsnjohnson*