### PR TITLE
🧹 [Code Health] Refactor duplicated search logic into shared helpers

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -2494,10 +2494,7 @@ function getFuzzyMatchScore(term, target) {
     return Math.max(40, 160 - spreadPenalty);
 }
 
-function computeSearchMatch(term, primaryText, secondaryText = '') {
-    const normalizedPrimary = normalizeSearchValue(primaryText);
-    if (!term || !normalizedPrimary) return { matched: false, score: -1, matchedByContent: false };
-
+function checkPrimarySearchMatch(term, normalizedPrimary) {
     if (normalizedPrimary === term) {
         return { matched: true, score: 520, matchedByContent: false };
     }
@@ -2513,6 +2510,26 @@ function computeSearchMatch(term, primaryText, secondaryText = '') {
     if (fuzzyScore >= 0) {
         return { matched: true, score: fuzzyScore, matchedByContent: false };
     }
+    return null;
+}
+
+function checkSecondarySearchMatch(term, normalizedSecondary) {
+    if (normalizedSecondary.includes(term)) {
+        return { matched: true, score: 180, matchedByContent: true };
+    }
+    const fuzzySecondaryScore = getFuzzyMatchScore(term, normalizedSecondary);
+    if (fuzzySecondaryScore >= 0) {
+        return { matched: true, score: Math.max(80, fuzzySecondaryScore - 40), matchedByContent: true };
+    }
+    return null;
+}
+
+function computeSearchMatch(term, primaryText, secondaryText = '') {
+    const normalizedPrimary = normalizeSearchValue(primaryText);
+    if (!term || !normalizedPrimary) return { matched: false, score: -1, matchedByContent: false };
+
+    const primaryMatch = checkPrimarySearchMatch(term, normalizedPrimary);
+    if (primaryMatch) return primaryMatch;
 
     // ⚡ Bolt: Defer expensive string normalization on potentially large secondary text
     // until after all primary fast-paths fail
@@ -2520,13 +2537,8 @@ function computeSearchMatch(term, primaryText, secondaryText = '') {
     const actualSecondaryText = typeof secondaryText === 'function' ? secondaryText() : secondaryText;
     const normalizedSecondary = normalizeSearchValue(actualSecondaryText);
     if (normalizedSecondary) {
-        if (normalizedSecondary.includes(term)) {
-            return { matched: true, score: 180, matchedByContent: true };
-        }
-        const fuzzySecondaryScore = getFuzzyMatchScore(term, normalizedSecondary);
-        if (fuzzySecondaryScore >= 0) {
-            return { matched: true, score: Math.max(80, fuzzySecondaryScore - 40), matchedByContent: true };
-        }
+        const secondaryMatch = checkSecondarySearchMatch(term, normalizedSecondary);
+        if (secondaryMatch) return secondaryMatch;
     }
 
     return { matched: false, score: -1, matchedByContent: false };
@@ -3423,30 +3435,12 @@ function sortSearchResults(results) {
 function computePrecomputedSearchMatch(term, normalizedPrimary, normalizedSecondary) {
     if (!term || !normalizedPrimary) return { matched: false, score: -1, matchedByContent: false };
 
-    if (normalizedPrimary === term) {
-        return { matched: true, score: 520, matchedByContent: false };
-    }
-    if (normalizedPrimary.startsWith(term)) {
-        return { matched: true, score: 430, matchedByContent: false };
-    }
-    const primaryIndex = normalizedPrimary.indexOf(term);
-    if (primaryIndex >= 0) {
-        return { matched: true, score: 320 - Math.min(primaryIndex, 120), matchedByContent: false };
-    }
-
-    const fuzzyScore = getFuzzyMatchScore(term, normalizedPrimary);
-    if (fuzzyScore >= 0) {
-        return { matched: true, score: fuzzyScore, matchedByContent: false };
-    }
+    const primaryMatch = checkPrimarySearchMatch(term, normalizedPrimary);
+    if (primaryMatch) return primaryMatch;
 
     if (normalizedSecondary) {
-        if (normalizedSecondary.includes(term)) {
-            return { matched: true, score: 180, matchedByContent: true };
-        }
-        const fuzzySecondaryScore = getFuzzyMatchScore(term, normalizedSecondary);
-        if (fuzzySecondaryScore >= 0) {
-            return { matched: true, score: Math.max(80, fuzzySecondaryScore - 40), matchedByContent: true };
-        }
+        const secondaryMatch = checkSecondarySearchMatch(term, normalizedSecondary);
+        if (secondaryMatch) return secondaryMatch;
     }
 
     return { matched: false, score: -1, matchedByContent: false };

--- a/tests/computeSearchMatch.test.js
+++ b/tests/computeSearchMatch.test.js
@@ -30,6 +30,8 @@ function extractFunctionSource(name) {
 const snippets = [
     extractFunctionSource('normalizeSearchValue'),
     extractFunctionSource('getFuzzyMatchScore'),
+    extractFunctionSource('checkPrimarySearchMatch'),
+    extractFunctionSource('checkSecondarySearchMatch'),
     extractFunctionSource('computeSearchMatch'),
     extractFunctionSource('computePrecomputedSearchMatch')
 ].join('\n');


### PR DESCRIPTION
🎯 **What:** Extracted duplicated primary and secondary string matching and scoring logic from `computeSearchMatch` and `computePrecomputedSearchMatch` into two shared helper functions: `checkPrimarySearchMatch` and `checkSecondarySearchMatch`.
💡 **Why:** Refactoring these duplicated blocks into single, centralized utility functions removes redundant code, makes future search improvements or weight adjustments safer and easier to apply consistently, and improves overall code readability.
✅ **Verification:** Updated `tests/computeSearchMatch.test.js` to extract and evaluate the new helper functions before extracting the main matchers. Ran the full `bun test` suite locally to confirm that the changes introduced zero regressions and the fallback/lazy-loading mechanisms remain intact.
✨ **Result:** A cleaner, deduplicated search matching module with identical runtime behavior.

---
*PR created automatically by Jules for task [7618861635099302784](https://jules.google.com/task/7618861635099302784) started by @jaxsnjohnson*