### PR TITLE
⚡ Bolt: O(1) Lookups for Map Markers and Routes

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -73,3 +73,7 @@
 ## 2024-05-27 - Lazy Initialization of Search Context Strings
 **Learning:** In the `searchMapMarkers` function, map marker objects were unconditionally executing expensive operations like string concatenation (`${poi.summary} ${poi.description}`) and normalization (`normalizeSearchValue()`) to populate `marker._searchContext` on the first iteration of the filter loop, even when the user was only toggling a category filter and had not entered a search term. This caused thousands of unnecessary string allocations and CPU cycles on complex maps.
 **Action:** Defer the initialization of expensive search strings (like normalized titles and concatenated descriptions) until they are actually required by the matching algorithm. Use a lazy-loading pattern by setting them to `null` initially and computing them on-demand inside the search condition (e.g., `if (hasSearchTerm && searchContext.normalizedPrimary === null) { ... }`).
+
+## 2024-05-30 - O(N) Array Searches Replaced with O(1) Map Lookups
+**Learning:** `allMapMarkers` array is frequently searched using `find` by POI ID and Name during route step focus (`focusRouteStep`) and map marker focus operations (`focusPOI`), which are linear O(N) operations. By caching this array into an O(1) ES6 `Map` by POI Name and ID whenever it is updated in `populatePOIsOnMap`, we can avoid the linear performance penalty.
+**Action:** Implemented caching Maps for `allMapMarkers` populated during map render to be used for O(1) fetching. Avoid overwriting first instance by checking `!Map.has()` first.

--- a/js/app.js
+++ b/js/app.js
@@ -155,6 +155,7 @@ let temporaryMouseMoveTooltip = null; // L.Tooltip for the temporary line's leng
 // --- GM / Routes / Session Toolkit State ---
 let gmContentVisible = false;
 let currentRoutes = [];
+let currentRoutesById = new Map(); // Bolt: O(1) lookups for routes
 let visibleRoutes = [];
 let currentRoute = null;
 let currentRouteStepIndex = -1;
@@ -641,6 +642,8 @@ let currentImageLayer = null;
 let currentMapUnderlay = null;
 let currentMarkerGroup = null; // Holds currently *visible* markers
 let allMapMarkers = []; // Holds *all* markers for the loaded map
+let allMapMarkersById = new Map(); // Bolt: O(1) lookups for markers
+let allMapMarkersByName = new Map(); // Bolt: O(1) lookups for markers
 let currentBounds = null;
 let currentlyLoadedMapId = null;
 let currentSidebarState = 'o';
@@ -3744,7 +3747,8 @@ function renderRouteSteps(activeStepId) {
     if (!routeStepList) return;
     routeStepList.innerHTML = '';
     const selectedRouteId = routeSelect?.value;
-    const route = currentRoutes.find(r => r.id === selectedRouteId);
+    // ⚡ Bolt: Use O(1) Map lookup instead of O(N) Array.find
+    const route = currentRoutesById.get(selectedRouteId);
     if (!route) return;
     route.steps.forEach(step => {
         const div = document.createElement('div');
@@ -3770,7 +3774,8 @@ function focusRouteStep(route, step) {
     renderRouteSteps(step.id);
     switch (step.targetType) {
         case 'poi': {
-            const marker = allMapMarkers.find(m => m.poiData && (m.poiData.id === step.targetId || m.poiData.name === step.targetId));
+            // ⚡ Bolt: Use O(1) Map lookup instead of O(N) Array.find
+            const marker = allMapMarkersById.get(step.targetId) || allMapMarkersByName.get(step.targetId);
             if (marker) {
                 map.flyTo(marker.getLatLng(), step.zoom != null ? step.zoom : Math.max(map.getZoom(), 1));
                 marker.openPopup();
@@ -3813,7 +3818,8 @@ function focusRouteStep(route, step) {
 }
 
 function startRoute(routeId, stepId = null) {
-    const route = currentRoutes.find(r => r.id === routeId) || currentRoutes[0];
+    // ⚡ Bolt: Use O(1) Map lookup instead of O(N) Array.find
+    const route = currentRoutesById.get(routeId) || currentRoutes[0];
     if (!route) return;
     currentRoute = route;
     const idx = stepId ? route.steps.findIndex(s => s.id === stepId) : 0;
@@ -4616,7 +4622,8 @@ window.openLinkedMapFromPopup = function(event, mapId) {
 };
 
 function focusPOI(poiName) {
-    const marker = allMapMarkers.find(m => m.poiData && m.poiData.name === poiName);
+    // ⚡ Bolt: Use O(1) Map lookup instead of O(N) Array.find
+    const marker = allMapMarkersByName.get(poiName);
     if (marker) {
         // Ensure marker is visible (add to group if not)
         if (!currentMarkerGroup.hasLayer(marker)) {
@@ -4845,6 +4852,8 @@ function resetMapState() {
     currentRegionGroup = null;
     currentRoadGroup = null;
     allMapMarkers = [];
+    allMapMarkersById.clear();
+    allMapMarkersByName.clear();
 }
 
 function populatePOIsOnMap(selectedMap) {
@@ -4865,6 +4874,12 @@ function populatePOIsOnMap(selectedMap) {
                         marker.bindTooltip(createPoiTooltipContent(point), getPoiTooltipOptions());
                         attachPoiTooltipBehavior(marker);
                         allMapMarkers.push(marker);
+                        if (point.id && !allMapMarkersById.has(point.id)) {
+                            allMapMarkersById.set(point.id, marker);
+                        }
+                        if (point.name && !allMapMarkersByName.has(point.name)) {
+                            allMapMarkersByName.set(point.name, marker);
+                        }
                     } else {
                         console.warn(`L.marker returned undefined for POI: ${point.name || 'Unnamed POI'}`);
                     }
@@ -4973,6 +4988,7 @@ function renderMapFeatures(selectedMap, requestedMapId) {
     visibleLinesCache = getVisibleLines(selectedMap);
     visibleRoutes = getVisibleRoutes(selectedMap);
     currentRoutes = visibleRoutes;
+    currentRoutesById = new Map(currentRoutes.map(route => [route.id, route]));
     currentEncounterTables = getVisibleEncounterTables(selectedMap);
     renderRoutesPanel();
     updateEncounterSelect();

--- a/tests/checkAndFocusFeature.test.js
+++ b/tests/checkAndFocusFeature.test.js
@@ -23,6 +23,7 @@ const path = require('path');
 
     // Global mocks
     global.allMapMarkers = [];
+    global.allMapMarkersByName = new Map();
     global.currentMarkerGroup = {
         layers: [],
         hasLayer: function(l) { return this.layers.includes(l); },
@@ -75,6 +76,7 @@ const path = require('path');
     // Reset state between tests
     function resetMocks() {
         global.allMapMarkers = [];
+        global.allMapMarkersByName.clear();
         global.currentMarkerGroup.layers = [];
         global.currentRegionGroup.layers = [];
         global.currentRoadGroup.layers = [];
@@ -94,6 +96,7 @@ const path = require('path');
             popupOpened: false
         };
         global.allMapMarkers.push(mockMarker);
+        global.allMapMarkersByName.set('Test POI', mockMarker);
         const resultPoi = focusPOI('Test POI');
         assert.equal(resultPoi, true, 'focusPOI should return true for found POI');
         assert.ok(mockMarker.popupOpened, 'Marker popup should be opened');
@@ -145,6 +148,7 @@ const path = require('path');
         // Test checkAndFocusFeature
         resetMocks();
         global.allMapMarkers.push(mockMarker);
+        global.allMapMarkersByName.set('Test POI', mockMarker);
         searchParams = { poi: 'Test POI' };
         const resultCheckPoi = checkAndFocusFeature();
         assert.equal(resultCheckPoi, true, 'checkAndFocusFeature should return true when POI is focused');


### PR DESCRIPTION
💡 **What**: Replaces O(N) array `.find()` calls on `allMapMarkers` and `currentRoutes` with O(1) `.get()` lookups from newly introduced Javascript `Map` objects (`allMapMarkersById`, `allMapMarkersByName`, `currentRoutesById`).

🎯 **Why**: When triggering `focusPOI` or rendering `focusRouteStep`, iterating the array structure linearly was unnecessary overhead.

📊 **Impact**: Reduces O(N) iterations to O(1) lookup latency for pointer dereferencing when interacting with maps hosting thousands of POIs.

🔬 **Measurement**: Verify via interaction speed of route stepping and direct POI focusing via API URLs.

---
*PR created automatically by Jules for task [16667636468536958951](https://jules.google.com/task/16667636468536958951) started by @jaxsnjohnson*