### PR TITLE
🧹 Refactor setupMapImageLoading to use options object

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -5162,7 +5162,7 @@ function setupMapLayers(selectedMap, requestedMapId, mapImageUrl, updateHash) {
     return true;
 }
 
-function setupMapImageLoading(requestedMapId, selectedMap, mapImageUrl, usingAlternateMobileImage, loadStartedAt, updateHash) {
+function setupMapImageLoading({ requestedMapId, selectedMap, mapImageUrl, usingAlternateMobileImage, loadStartedAt, updateHash }) {
     const preloadImg = new Image();
     let loadingComplete = false;
     let loadingTimeout = null;
@@ -5220,7 +5220,7 @@ async function loadMap(mapId, updateHash = true, preResolvedMap = null) {
 
     if (!setupMapLayers(selectedMap, requestedMapId, mapImageUrl, updateHash)) return;
 
-    setupMapImageLoading(requestedMapId, selectedMap, mapImageUrl, usingAlternateMobileImage, loadStartedAt, updateHash);
+    setupMapImageLoading({ requestedMapId, selectedMap, mapImageUrl, usingAlternateMobileImage, loadStartedAt, updateHash });
 
     renderMapFeatures(selectedMap, requestedMapId);
     finalizeMapUI(requestedMapId, selectedMap);


### PR DESCRIPTION
* 🎯 **What:** Changed `setupMapImageLoading` to accept a single options object instead of 6 individual parameters.
* 💡 **Why:** Having too many parameters in a function signature makes it harder to read and easier to introduce bugs by passing parameters in the wrong order. Refactoring to an options object improves maintainability.
* ✅ **Verification:** Verified locally and ran the test suite (`bun test`). No behavior changed.
* ✨ **Result:** A more readable, maintainable codebase that follows best practices for function parameters.

---
*PR created automatically by Jules for task [369258607780761135](https://jules.google.com/task/369258607780761135) started by @jaxsnjohnson*