### PR TITLE
🔒 [Fix DOM-based XSS in map-editor parent options]

### DIFF
--- a/js/map-editor.js
+++ b/js/map-editor.js
@@ -785,10 +785,16 @@
         const parentSelect = inputs.parentIdSelect;
         const options = buildParentOptions();
         if (parentSelect) {
-            parentSelect.innerHTML = options.map((option) => {
-                const selected = option.id === (currentLocation?.parentId || '') ? ' selected' : '';
-                return `<option value="${escapeHtml(option.id)}"${selected}>${escapeHtml(option.label)}</option>`;
-            }).join('');
+            parentSelect.innerHTML = '';
+            options.forEach((option) => {
+                const optEl = document.createElement('option');
+                optEl.value = option.id;
+                optEl.textContent = option.label;
+                if (option.id === (currentLocation?.parentId || '')) {
+                    optEl.selected = true;
+                }
+                parentSelect.appendChild(optEl);
+            });
         }
 
         dom.currentMapId.textContent = currentMap?.id || 'No map';


### PR DESCRIPTION
🎯 **What:** Fixed a DOM-based XSS vulnerability in the map-editor where parent select options were built using `innerHTML` string interpolation.
⚠️ **Risk:** Although `escapeHtml` was previously used, building and assigning complex HTML structures directly into `innerHTML` is an anti-pattern that can lead to subtle bypasses or bugs (like XSS injections) if attributes are mishandled or data isn't escaped accurately in all contexts.
🛡️ **Solution:** Refactored the `renderMapSettingsForm` method to dynamically create `<option>` elements using `document.createElement`. Data is now safely injected via the `.value` and `.textContent` properties directly, eliminating the risk of HTML parsing vulnerabilities entirely without double-escaping entities.

---
*PR created automatically by Jules for task [13891454352798307609](https://jules.google.com/task/13891454352798307609) started by @jaxsnjohnson*