### PR TITLE
🧹 Flatten theme token validation

### DIFF
--- a/js/app-config.js
+++ b/js/app-config.js
@@ -277,7 +277,8 @@
             .replace(/`/g, '&#96;');
     }
 
-const COLOR_LIKE_PATTERN = /^(#[0-9a-f]{3,8}|rgba?\([^)]+\)|hsla?\([^)]+\)|[a-z]+|var\(--[a-z0-9_-]+\)|transparent|white|black)$/i;
+    const COLOR_LIKE_PATTERN = /^(#[0-9a-f]{3,8}|rgba?\([^)]+\)|hsla?\([^)]+\)|[a-z]+|var\(--[a-z0-9_-]+\)|transparent|white|black)$/i;
+    const COLOR_LIKE_TOKEN_KEYWORDS = ['color', 'bg', 'ring', 'thumb', 'slider', 'text'];
 
     function isPlainObject(value) {
         return Boolean(value) && typeof value === 'object' && !Array.isArray(value);
@@ -325,6 +326,31 @@ const COLOR_LIKE_PATTERN = /^(#[0-9a-f]{3,8}|rgba?\([^)]+\)|hsla?\([^)]+\)|[a-z]
         return merged;
     }
 
+    function isColorLikeTokenKey(key) {
+        return COLOR_LIKE_TOKEN_KEYWORDS.some((keyword) => key.includes(keyword));
+    }
+
+    function validateThemeTokenValue(mode, key, rawValue, errors) {
+        if (!isColorLikeTokenKey(key)) return;
+
+        const value = String(rawValue || '').trim();
+        if (!value || COLOR_LIKE_PATTERN.test(value)) return;
+
+        errors.push(`theme.tokens.${mode}.${key} has an invalid color-like value.`);
+    }
+
+    function validateThemeTokens(themeTokens, errors) {
+        ['light', 'dark'].forEach((mode) => {
+            const tokens = themeTokens[mode];
+            if (!isPlainObject(tokens)) {
+                errors.push(`theme.tokens.${mode} must be an object.`);
+                return;
+            }
+
+            Object.keys(tokens).forEach((key) => validateThemeTokenValue(mode, key, tokens[key], errors));
+        });
+    }
+
     function validateConfig(config) {
         const candidate = normalizeConfig(config);
         const errors = [];
@@ -334,21 +360,7 @@ const COLOR_LIKE_PATTERN = /^(#[0-9a-f]{3,8}|rgba?\([^)]+\)|hsla?\([^)]+\)|[a-z]
         if (!Array.isArray(candidate.assets.stylesheets) || candidate.assets.stylesheets.length === 0) errors.push('assets.stylesheets must list at least one stylesheet.');
         if (!isPlainObject(candidate.assets.poiIcons) || !candidate.assets.poiIcons.Unknown) errors.push('assets.poiIcons.Unknown is required.');
         if (!isPlainObject(candidate.taxonomy.poiTypeGroups) || !Array.isArray(candidate.taxonomy.poiTypeGroups.Unknown)) errors.push('taxonomy.poiTypeGroups.Unknown must be an array.');
-        ['light', 'dark'].forEach((mode) => {
-            const tokens = candidate.theme.tokens[mode];
-            if (!isPlainObject(tokens)) {
-                errors.push(`theme.tokens.${mode} must be an object.`);
-                return;
-            }
-            Object.keys(tokens).forEach((key) => {
-                const value = String(tokens[key] || '').trim();
-                if (key.includes('color') || key.includes('bg') || key.includes('ring') || key.includes('thumb') || key.includes('slider') || key.includes('text')) {
-                    if (value && !COLOR_LIKE_PATTERN.test(value)) {
-                        errors.push(`theme.tokens.${mode}.${key} has an invalid color-like value.`);
-                    }
-                }
-            });
-        });
+        validateThemeTokens(candidate.theme.tokens, errors);
         if (!Number.isFinite(Number(candidate.performance.mobileBreakpoint)) || Number(candidate.performance.mobileBreakpoint) < 320) {
             errors.push('performance.mobileBreakpoint must be a number >= 320.');
         }


### PR DESCRIPTION
## 🎯 What

Refactored the theme token validation in `js/app-config.js` to remove the deeply nested color-like token checks.

## 💡 Why

The validation logic now separates token-key classification, single-token validation, and mode-level traversal. This makes the behavior easier to read and maintain without changing the existing error messages or validation rules.

## ✅ Verification

- `node --check js/app-config.js`
- `node tests/site-config.test.js`
- `node --test $(rg --files-without-match "bun:test" tests/*.test.js)`

Note: `node --test tests/*.test.js` still cannot run the five `bun:test` files in this environment because Bun is not installed and Node rejects the `bun:` import scheme.

## ✨ Result

`validateConfig` now delegates theme-token validation to smaller, flatter helper functions while preserving the existing config validation behavior.