### PR TITLE
🧹 Flatten file-backed manifest hydration

### DIFF
--- a/js/editor-shared.js
+++ b/js/editor-shared.js
@@ -521,30 +521,34 @@
             return cloneJson(await cache.get(normalizedId));
         }
 
+        function shouldLoadFileBackedPayload(mapData, normalizedId) {
+            if (!normalizedId) return false;
+            if (!String(mapData.dataUrl || '').trim()) return false;
+            return !hasInlineEditableMapPayload(mapData);
+        }
+
+        async function mergeFileBackedPayload(mapData, normalizedId) {
+            if (!shouldLoadFileBackedPayload(mapData, normalizedId)) return mapData;
+
+            try {
+                const loadedMap = await fetchMap(normalizedId, mapData);
+                if (!loadedMap || typeof loadedMap !== 'object') return mapData;
+
+                return {
+                    ...cloneJson(loadedMap),
+                    ...mapData
+                };
+            } catch (error) {
+                return createUnavailableMapEntry(normalizedId, error?.message || 'Unknown error.');
+            }
+        }
+
         async function hydrateNode(node) {
             if (!node || typeof node !== 'object') return null;
 
             let hydrated = cloneJson(node);
             const normalizedId = String(hydrated.id || '').trim();
-            const explicitDataUrl = String(hydrated.dataUrl || '').trim();
-
-            if (
-                normalizedId &&
-                explicitDataUrl &&
-                !hasInlineEditableMapPayload(hydrated)
-            ) {
-                try {
-                    const loadedMap = await fetchMap(normalizedId, hydrated);
-                    if (loadedMap && typeof loadedMap === 'object') {
-                        hydrated = {
-                            ...cloneJson(loadedMap),
-                            ...hydrated
-                        };
-                    }
-                } catch (error) {
-                    return createUnavailableMapEntry(normalizedId, error?.message || 'Unknown error.');
-                }
-            }
+            hydrated = await mergeFileBackedPayload(hydrated, normalizedId);
 
             if (resolveDataUrl && hydrated.id && hydrated.imageUrl && !hydrated.dataUrl) {
                 hydrated.dataUrl = resolveDataUrl(hydrated.id, hydrated);


### PR DESCRIPTION
## 🎯 What
Refactored the file-backed manifest hydration path in `js/editor-shared.js` to move the nested external payload load/merge logic into small helper functions.

## 💡 Why
`hydrateNode` now reads as a flatter sequence of steps, making the external payload decision and merge behavior easier to scan and maintain without changing the merge precedence or error handling behavior.

## ✅ Verification
- `node --check js/editor-shared.js`
- `node tests/file-backed-manifest-hydration.test.js`
- Ran all Node-compatible `tests/*.test.js` files successfully, skipping the five `bun:test` files because `bun` is not installed in this environment.

## ✨ Result
The deeply nested block is removed from `hydrateNode`, while file-backed payload loading, unavailable-map fallback behavior, data URL resolution, and child hydration behavior are preserved.