### PR TITLE
🧪 [testing improvement] Add test for fetchJsonAsset

### DIFF
--- a/tests/fetchJsonAsset.test.js
+++ b/tests/fetchJsonAsset.test.js
@@ -1,0 +1,40 @@
+import { describe, it, expect, beforeEach, afterEach, mock } from 'bun:test';
+
+const SharedUtils = require('../js/shared-utils.js');
+
+describe('fetchJsonAsset', () => {
+    let originalFetch;
+    let originalWindow;
+
+    beforeEach(() => {
+        originalFetch = global.fetch;
+        originalWindow = global.window;
+
+        global.window = { APP_ASSET_VERSION: '1.0' };
+
+        global.fetch = mock();
+    });
+
+    afterEach(() => {
+        global.fetch = originalFetch;
+        global.window = originalWindow;
+    });
+
+    it('fetches json asset with correct version parameter', async () => {
+        const mockResponse = { ok: true, json: mock().mockResolvedValue({ data: 'test' }) };
+        global.fetch.mockResolvedValue(mockResponse);
+
+        const result = await SharedUtils.fetchJsonAsset('test.json');
+
+        expect(global.fetch).toHaveBeenCalledWith('test.json?v=1.0');
+        expect(mockResponse.json).toHaveBeenCalled();
+        expect(result).toEqual({ data: 'test' });
+    });
+
+    it('throws error when response is not ok', async () => {
+        const mockResponse = { ok: false, status: 404, statusText: 'Not Found' };
+        global.fetch.mockResolvedValue(mockResponse);
+
+        await expect(SharedUtils.fetchJsonAsset('test.json')).rejects.toThrow('Failed to load test.json: 404 Not Found');
+    });
+});


### PR DESCRIPTION
🎯 **What:** The `fetchJsonAsset` function located in `js/shared-utils.js` lacked testing coverage, leaving the happy path of fetching the correct URL with asset versioning, and the error branch of handling invalid responses, unverified.

📊 **Coverage:** The function is completely covered. We mock the `window.APP_ASSET_VERSION` object and the global `fetch` to verify: 
- It fetches the asset appropriately appending the `?v=` suffix. 
- It parses the response successfully.
- It intercepts invalid statuses (`!response.ok`), and correctly parses and throws descriptive errors as expected.

✨ **Result:** A robust new test suite leveraging `bun:test` verifies that asset loading errors bubble predictably and ensures successful JSON responses return un-obfuscated. Code reliability for module imports and fetching features across this codebase has increased.

---
*PR created automatically by Jules for task [2183556455621099655](https://jules.google.com/task/2183556455621099655) started by @jaxsnjohnson*