### PR TITLE
🧪 [testing improvement] Add test for exportAtlasStructure

### DIFF
--- a/tests/exportAtlasStructure.test.js
+++ b/tests/exportAtlasStructure.test.js
@@ -1,0 +1,149 @@
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+
+const appSource = fs.readFileSync('js/map-editor.js', 'utf8');
+
+const fnStart = appSource.indexOf('function exportAtlasStructure() {');
+const fnEnd = appSource.indexOf('async function selectMap(', fnStart);
+
+if (fnStart === -1 || fnEnd === -1 || fnEnd <= fnStart) {
+    throw new Error('Could not locate exportAtlasStructure in js/map-editor.js');
+}
+
+const fnSource = appSource.slice(fnStart, fnEnd);
+
+// Setup globals required by the eval
+global.utils = {};
+global.state = {};
+global.readMapSettingsForm = () => {};
+global.downloadJsonFile = () => {};
+global.setExportStatus = () => {};
+
+// Eval the function so it becomes globally available in the test context
+// eslint-disable-next-line no-eval
+eval(fnSource);
+
+// --- Mocks ---
+
+let serializeFlatManifestStateArgs = null;
+let serializeFlatManifestStateError = null;
+global.utils.serializeFlatManifestState = (args) => {
+    serializeFlatManifestStateArgs = args;
+    if (serializeFlatManifestStateError) {
+        throw serializeFlatManifestStateError;
+    }
+    return { mockManifest: true };
+};
+
+let downloadJsonFileArgs = null;
+global.downloadJsonFile = (filename, value) => {
+    downloadJsonFileArgs = { filename, value };
+};
+
+let exportStatusMessage = null;
+let exportStatusIsError = null;
+global.setExportStatus = (message, isError) => {
+    exportStatusMessage = message;
+    exportStatusIsError = isError;
+};
+
+let readMapSettingsFormCalled = false;
+global.readMapSettingsForm = () => {
+    readMapSettingsFormCalled = true;
+    return { mockSettings: true };
+};
+
+const originalConsoleError = console.error;
+let consoleErrorArgs = null;
+console.error = (...args) => {
+    consoleErrorArgs = args;
+};
+
+// Reset mocks before each test
+function resetMocks() {
+    serializeFlatManifestStateArgs = null;
+    serializeFlatManifestStateError = null;
+    downloadJsonFileArgs = null;
+    exportStatusMessage = null;
+    exportStatusIsError = null;
+    readMapSettingsFormCalled = false;
+    consoleErrorArgs = null;
+
+    global.state = {
+        atlasTree: [{ id: 'mock-tree-node' }],
+        currentMapId: '',
+        currentMap: null
+    };
+}
+
+// --- Tests ---
+
+// 1. Happy path: With currentMap
+resetMocks();
+global.state.currentMapId = 'map-123';
+global.state.currentMap = { id: 'map-123' };
+
+exportAtlasStructure();
+
+assert.equal(readMapSettingsFormCalled, true);
+assert.deepEqual(serializeFlatManifestStateArgs, {
+    masterMapData: [{ id: 'mock-tree-node' }],
+    currentMapId: 'map-123',
+    mapSettings: { mockSettings: true }
+});
+assert.deepEqual(downloadJsonFileArgs, {
+    filename: 'maps.json',
+    value: { mockManifest: true }
+});
+assert.equal(exportStatusMessage, 'Exported maps.json.');
+assert.equal(exportStatusIsError, undefined);
+assert.equal(consoleErrorArgs, null);
+
+// 2. Happy path: Without currentMap
+resetMocks();
+global.state.currentMapId = '';
+global.state.currentMap = null;
+
+exportAtlasStructure();
+
+assert.equal(readMapSettingsFormCalled, false);
+assert.deepEqual(serializeFlatManifestStateArgs, {
+    masterMapData: [{ id: 'mock-tree-node' }],
+    currentMapId: '',
+    mapSettings: {}
+});
+assert.deepEqual(downloadJsonFileArgs, {
+    filename: 'maps.json',
+    value: { mockManifest: true }
+});
+assert.equal(exportStatusMessage, 'Exported maps.json.');
+assert.equal(exportStatusIsError, undefined);
+assert.equal(consoleErrorArgs, null);
+
+// 3. Error path: Exception thrown
+resetMocks();
+const mockError = new Error('Test mock error');
+serializeFlatManifestStateError = mockError;
+
+exportAtlasStructure();
+
+assert.equal(downloadJsonFileArgs, null);
+assert.deepEqual(consoleErrorArgs, [mockError]);
+assert.equal(exportStatusMessage, 'Test mock error');
+assert.equal(exportStatusIsError, true);
+
+// 4. Error path: Exception with no message
+resetMocks();
+serializeFlatManifestStateError = 'String error'; // No .message
+
+exportAtlasStructure();
+
+assert.equal(downloadJsonFileArgs, null);
+assert.deepEqual(consoleErrorArgs, ['String error']);
+assert.equal(exportStatusMessage, 'Could not export maps.json.');
+assert.equal(exportStatusIsError, true);
+
+// Restore original console.error
+console.error = originalConsoleError;
+
+console.log('exportAtlasStructure tests passed');


### PR DESCRIPTION
🎯 **What:** Added comprehensive unit tests for the `exportAtlasStructure` function within `js/map-editor.js`, validating its behavior under various conditions and ensuring reliable JSON exportation.

📊 **Coverage:** The tests verify:
- Happy path when `state.currentMap` is successfully exported, including verifying arguments passed to mocked utility dependencies.
- Happy path when `state.currentMap` is unset, verifying empty parameter fallbacks.
- Error path when dependencies trigger an exception with an explicit message.
- Error path when dependencies throw an unspecified string exception, verifying fallbacks for log outputs and export status.

✨ **Result:** Enhanced the testing reliability and coverage of the map editor module, protecting the functionality of the atlas structure exporter from future regressions without introducing additional library dependencies or test flakiness.

---
*PR created automatically by Jules for task [677223813960187410](https://jules.google.com/task/677223813960187410) started by @jaxsnjohnson*