### PR TITLE
🧹 Remove backward compatibility stub for sanitizeWikiLinkForHref in tests

### DIFF
--- a/tests/createPopupContent.test.js
+++ b/tests/createPopupContent.test.js
@@ -14,6 +14,7 @@ if (
     formatStart === -1 ||
     sanitizeStart === -1 ||
     escapeStart === -1 ||
+    wikiLinkStart === -1 ||
     resolveStart === -1 ||
     popupStart === -1 ||
     popupEnd === -1
@@ -23,8 +24,8 @@ if (
 
 const formatSource = appSource.slice(formatStart, sanitizeStart);
 const sanitizeSource = appSource.slice(sanitizeStart, escapeStart);
-const escapeSource = appSource.slice(escapeStart, wikiLinkStart !== -1 ? wikiLinkStart : resolveStart);
-const wikiLinkSource = wikiLinkStart !== -1 ? appSource.slice(wikiLinkStart, resolveStart) : '';
+const escapeSource = appSource.slice(escapeStart, wikiLinkStart);
+const wikiLinkSource = appSource.slice(wikiLinkStart, resolveStart);
 const popupSource = appSource.slice(popupStart, popupEnd);
 
 // Minimal dependency stub for this regression check.
@@ -38,13 +39,8 @@ eval(formatSource);
 eval(sanitizeSource);
 // eslint-disable-next-line no-eval
 eval(escapeSource);
-if (wikiLinkSource) {
-    // eslint-disable-next-line no-eval
-    eval(wikiLinkSource);
-} else {
-    // Backward compatibility for pre-fix snapshots.
-    global.sanitizeWikiLinkForHref = (value) => value;
-}
+// eslint-disable-next-line no-eval
+eval(wikiLinkSource);
 // eslint-disable-next-line no-eval
 eval(popupSource);
 


### PR DESCRIPTION
🎯 **What:** Removed the temporary backward-compatibility stub for `sanitizeWikiLinkForHref` in `tests/createPopupContent.test.js`.
💡 **Why:** The temporary stub was in place for pre-fix snapshots. Now that the logic and snapshots have been updated, the fallback `if/else` block and optional logic for determining index boundaries was no longer necessary and could be cleaned up to strictly test the file's current state.
✅ **Verification:** Verified via `bun test` that the `createPopupContent.test.js` continues to safely pass, throwing appropriately if dependencies are strictly missing.
✨ **Result:** Cleaner and strictly correct tests that no longer rely on outdated legacy stubs.

---
*PR created automatically by Jules for task [9460215850835752573](https://jules.google.com/task/9460215850835752573) started by @jaxsnjohnson*