### PR TITLE
🧹 Flatten filter checkbox update logic

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -761,6 +761,19 @@ function getStaticPoiFilterCheckboxes() {
     }
     return staticPoiFilterCheckboxesCache || [];
 }
+
+function setFilterCheckboxesChecked(checked) {
+    if (!poiFilterCheckboxesLive) return;
+
+    const staticCheckboxes = getStaticPoiFilterCheckboxes();
+    for (let i = 0; i < staticCheckboxes.length; i++) {
+        const checkbox = staticCheckboxes[i];
+        if (checkbox.type !== 'checkbox' || checkbox.id === 'filter-toggle-all') continue;
+
+        checkbox.checked = checked;
+    }
+}
+
 if (poiFilterContainer) {
     const observer = new MutationObserver(() => {
         staticPoiFilterCheckboxesCache = null;
@@ -3195,15 +3208,7 @@ if (searchRefineClearBtn) {
 
         filterToggleAllCheckbox.checked = true;
         filterToggleAllCheckbox.indeterminate = false;
-        if (poiFilterCheckboxesLive) {
-            // ⚡ Bolt: Convert live HTMLCollection to a static array for O(1) length and index access (Measured improvement: ~91% faster)
-            const staticCheckboxes = getStaticPoiFilterCheckboxes();
-            for (let i = 0; i < staticCheckboxes.length; i++) {
-                if (staticCheckboxes[i].type === 'checkbox' && staticCheckboxes[i].id !== 'filter-toggle-all') {
-                    staticCheckboxes[i].checked = true;
-                }
-            }
-        }
+        setFilterCheckboxesChecked(true);
 
         updateToggleAllCheckboxState();
         updateVisibleMarkersAndSearch();
@@ -6558,15 +6563,7 @@ poiFilterContainer.addEventListener('change', (e) => {
     // Handle master "Show All / Hide All" checkbox
     if (target.id === 'filter-toggle-all') {
         const isChecked = target.checked;
-        if (poiFilterCheckboxesLive) {
-            // ⚡ Bolt: Convert live HTMLCollection to a static array for O(1) length and index access (Measured improvement: ~91% faster)
-            const staticCheckboxes = getStaticPoiFilterCheckboxes();
-            for (let i = 0; i < staticCheckboxes.length; i++) {
-                if (staticCheckboxes[i].type === 'checkbox' && staticCheckboxes[i].id !== 'filter-toggle-all') {
-                    staticCheckboxes[i].checked = isChecked;
-                }
-            }
-        }
+        setFilterCheckboxesChecked(isChecked);
         filterToggleAllCheckbox.indeterminate = false;
     }
 

--- a/tests/setFilterCheckboxesChecked.test.js
+++ b/tests/setFilterCheckboxesChecked.test.js
@@ -1,0 +1,43 @@
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+
+const appSource = fs.readFileSync('js/app.js', 'utf8');
+
+const fnStart = appSource.indexOf('function setFilterCheckboxesChecked(checked) {');
+const fnEnd = appSource.indexOf('if (poiFilterContainer) {', fnStart);
+if (fnStart === -1 || fnEnd === -1 || fnEnd <= fnStart) {
+    throw new Error('Could not locate setFilterCheckboxesChecked function in js/app.js');
+}
+
+let poiFilterCheckboxesLive = null;
+let staticCheckboxes = [];
+function getStaticPoiFilterCheckboxes() {
+    return staticCheckboxes;
+}
+
+// eslint-disable-next-line no-eval
+eval(appSource.slice(fnStart, fnEnd));
+
+assert.doesNotThrow(() => setFilterCheckboxesChecked(true), 'Should no-op when filters are unavailable');
+
+const masterToggle = { type: 'checkbox', id: 'filter-toggle-all', checked: false };
+const poiFilter = { type: 'checkbox', id: 'filter-poi-city', checked: false };
+const regionFilter = { type: 'checkbox', id: 'filter-region-forest', checked: false };
+const textInput = { type: 'text', id: 'filter-search', checked: false };
+
+staticCheckboxes = [masterToggle, poiFilter, regionFilter, textInput];
+poiFilterCheckboxesLive = staticCheckboxes;
+
+setFilterCheckboxesChecked(true);
+assert.equal(masterToggle.checked, false, 'Should not update the master toggle');
+assert.equal(poiFilter.checked, true, 'Should check POI filter checkboxes');
+assert.equal(regionFilter.checked, true, 'Should check region filter checkboxes');
+assert.equal(textInput.checked, false, 'Should not update non-checkbox inputs');
+
+setFilterCheckboxesChecked(false);
+assert.equal(masterToggle.checked, false, 'Should still leave the master toggle unchanged');
+assert.equal(poiFilter.checked, false, 'Should uncheck POI filter checkboxes');
+assert.equal(regionFilter.checked, false, 'Should uncheck region filter checkboxes');
+assert.equal(textInput.checked, false, 'Should still leave non-checkbox inputs unchanged');
+
+console.log('setFilterCheckboxesChecked tests passed');


### PR DESCRIPTION
## 🎯 What
Refactored the repeated filter checkbox update loop into `setFilterCheckboxesChecked(checked)` and replaced the deeply nested clear-filter block with a direct helper call. The same helper now also serves the master filter toggle path.

## 💡 Why
The clear action had nested control flow for a shared operation: updating every non-master filter checkbox. Extracting that operation gives the event handlers a flatter shape, names the intent, and keeps the skip rules for the master toggle and non-checkbox inputs in one place.

## ✅ Verification
- `node --check js/app.js`
- `node --check tests/setFilterCheckboxesChecked.test.js`
- `node tests/setFilterCheckboxesChecked.test.js`
- `for test in tests/*.test.js; do if rg -q "bun:test" "$test"; then continue; fi; node "$test" || exit 1; done`
- Rebased PR source check: `node --check /private/tmp/app-rebased-237.js`
- Rebased focused test check: `node tests/setFilterCheckboxesChecked.test.js` from `/private/tmp/rebased-check-237`

Note: a raw `node tests/*.test.js` sweep is not valid for the full suite because six existing tests import `bun:test`, and Bun is not installed in this environment.

## ✨ Result
The filter reset behavior is preserved, the targeted nested block is flattened, duplicate checkbox update logic is removed, and a focused regression test now covers the helper's skip/update behavior.