### PR TITLE
🧹 Flatten manifest entry traversal

### DIFF
--- a/js/editor-shared.js
+++ b/js/editor-shared.js
@@ -105,27 +105,36 @@
             ];
         const flattenedEntries = [];
 
+        function createFlatEntry(item, index, parentId) {
+            const normalizedId = String(item.id || '').trim();
+            if (!normalizedId) return null;
+
+            const entry = {};
+            keysToCopy.forEach((key) => {
+                if (item[key] === undefined) return;
+                if (typeof item[key] === 'string' && !String(item[key]).trim() && key !== 'name') return;
+                entry[key] = cloneJson(item[key]);
+            });
+
+            entry.id = normalizedId;
+            entry.order = index;
+            if (parentId) entry.parentId = parentId;
+            return entry;
+        }
+
+        function appendFlatEntry(item, index, parentId) {
+            if (!item || typeof item !== 'object') return;
+
+            const entry = createFlatEntry(item, index, parentId);
+            if (!entry) return;
+
+            flattenedEntries.push(entry);
+            walk(item.children, entry.id);
+        }
+
         function walk(nodes, parentId = '') {
             if (!Array.isArray(nodes)) return;
-            nodes.forEach((item, index) => {
-                if (!item || typeof item !== 'object' || !String(item.id || '').trim()) return;
-
-                const entry = {};
-                keysToCopy.forEach((key) => {
-                    if (item[key] === undefined) return;
-                    if (typeof item[key] === 'string' && !String(item[key]).trim() && key !== 'name') return;
-                    entry[key] = cloneJson(item[key]);
-                });
-
-                entry.id = String(item.id || '').trim();
-                entry.order = index;
-                if (parentId) entry.parentId = parentId;
-                flattenedEntries.push(entry);
-
-                if (Array.isArray(item.children) && item.children.length > 0) {
-                    walk(item.children, entry.id);
-                }
-            });
+            nodes.forEach((item, index) => appendFlatEntry(item, index, parentId));
         }
 
         walk(items);


### PR DESCRIPTION
## 🎯 What
Refactored `buildFlatManifestEntries` in `js/editor-shared.js` to split flat entry creation and traversal into smaller local helpers.

## 💡 Why
The manifest-flattening walker had validation, field copying, entry mutation, accumulation, and child recursion nested inside one callback. Separating entry creation from traversal makes the control flow shallower and easier to maintain without changing behavior.

## ✅ Verification
- `node --check js/editor-shared.js`
- `node tests/editor-shared.test.js`
- `node tests/file-backed-manifest-hydration.test.js`
- Ran every `tests/*.test.js` file that does not import `bun:test` with Node; all passed.
- Attempted the full Node loop, but Bun-specific tests cannot run under Node because they import `bun:test`; `bun` is not installed in this environment.
- `git diff --check`

## ✨ Result
Manifest entries are still flattened in the same order with the same copied fields, `order`, and `parentId` behavior, but the traversal code no longer contains the deeply nested callback block.