### PR TITLE
🧹 Refactor lat/lon bounds settings

### DIFF
--- a/js/editor-shared.js
+++ b/js/editor-shared.js
@@ -648,6 +648,40 @@
         delete target[key];
     }
 
+    const LAT_LON_BOUND_KEYS = ['north', 'south', 'east', 'west'];
+
+    function parseLatLonBoundValue(value) {
+        const rawValue = String(value ?? '').trim();
+        if (!rawValue) return null;
+
+        const parsedValue = parseFloat(rawValue);
+        return Number.isFinite(parsedValue) ? parsedValue : null;
+    }
+
+    function buildLatLonBounds(latLonBounds) {
+        const nextBounds = {};
+        LAT_LON_BOUND_KEYS.forEach((key) => {
+            const parsedValue = parseLatLonBoundValue(latLonBounds[key]);
+            if (parsedValue !== null) {
+                nextBounds[key] = parsedValue;
+            }
+        });
+
+        return Object.keys(nextBounds).length > 0 ? nextBounds : null;
+    }
+
+    function assignLatLonBounds(mapToUpdate, latLonBounds) {
+        if (!latLonBounds || typeof latLonBounds !== 'object') return;
+
+        const nextBounds = buildLatLonBounds(latLonBounds);
+        if (nextBounds) {
+            mapToUpdate.latLonBounds = nextBounds;
+            return;
+        }
+
+        delete mapToUpdate.latLonBounds;
+    }
+
     function applyMapSettings(mapToUpdate, mapSettings = {}) {
         if (!mapToUpdate || typeof mapToUpdate !== 'object') return mapToUpdate;
 
@@ -676,23 +710,7 @@
         assignNumberField(mapToUpdate, 'scalePixels', mapSettings.scalePixels, { integer: true });
         assignNumberField(mapToUpdate, 'scaleKilometers', mapSettings.scaleKilometers);
 
-        if (mapSettings.latLonBounds && typeof mapSettings.latLonBounds === 'object') {
-            const nextBounds = {};
-            ['north', 'south', 'east', 'west'].forEach((key) => {
-                const rawValue = String(mapSettings.latLonBounds[key] ?? '').trim();
-                if (!rawValue) return;
-                const parsedValue = parseFloat(rawValue);
-                if (Number.isFinite(parsedValue)) {
-                    nextBounds[key] = parsedValue;
-                }
-            });
-
-            if (Object.keys(nextBounds).length > 0) {
-                mapToUpdate.latLonBounds = nextBounds;
-            } else {
-                delete mapToUpdate.latLonBounds;
-            }
-        }
+        assignLatLonBounds(mapToUpdate, mapSettings.latLonBounds);
     }
 
     function stripStructureFieldsFromMapDocument(mapDocument) {

--- a/tests/editor-shared.test.js
+++ b/tests/editor-shared.test.js
@@ -369,6 +369,51 @@ assert.deepEqual(mapSettingsTarget.latLonBounds, {
     west: -5
 });
 
+const partialLatLonBoundsTarget = {
+    latLonBounds: {
+        north: 1,
+        south: 0
+    }
+};
+applyMapSettings(partialLatLonBoundsTarget, {
+    latLonBounds: {
+        north: ' 42 ',
+        south: '',
+        east: 'not-a-number',
+        west: '0'
+    }
+});
+assert.deepEqual(partialLatLonBoundsTarget.latLonBounds, {
+    north: 42,
+    west: 0
+});
+
+const emptyLatLonBoundsTarget = {
+    latLonBounds: {
+        north: 1
+    }
+};
+applyMapSettings(emptyLatLonBoundsTarget, {
+    latLonBounds: {
+        north: '',
+        south: 'not-a-number',
+        east: null
+    }
+});
+assert.equal(emptyLatLonBoundsTarget.latLonBounds, undefined);
+
+const ignoredLatLonBoundsTarget = {
+    latLonBounds: {
+        north: 1
+    }
+};
+applyMapSettings(ignoredLatLonBoundsTarget, {
+    latLonBounds: null
+});
+assert.deepEqual(ignoredLatLonBoundsTarget.latLonBounds, {
+    north: 1
+});
+
 // applyMapSettings edge cases
 assert.equal(applyMapSettings(null), null);
 assert.equal(applyMapSettings(undefined), undefined);


### PR DESCRIPTION
## 🎯 What
Refactored lat/lon bounds handling in `applyMapSettings` by extracting parsing, bounds construction, and assignment into focused helpers. Added regression coverage for partial, empty/invalid, and ignored non-object bounds input.

## 💡 Why
This removes the deeply nested block from `applyMapSettings`, making the settings update path easier to scan while preserving the existing behavior for valid, invalid, empty, and absent bounds.

## ✅ Verification
- `node --check js/editor-shared.js`
- `node tests/editor-shared.test.js`
- `npx --yes bun test tests/*.test.js`
- `git diff --check`

## ✨ Result
`applyMapSettings` now delegates lat/lon bounds normalization to small helpers, reducing local complexity without changing behavior.