### PR TITLE
🧹 Refactor map selection traversal

### DIFF
--- a/js/editor-shared.js
+++ b/js/editor-shared.js
@@ -573,39 +573,47 @@
         const selections = [];
         const seenIds = new Set();
 
+        function buildSelectionEntry(item) {
+            const normalizedId = String(item.id || '').trim();
+            const label = String(item.name || normalizedId || '').trim();
+            const isLoadable = Boolean(
+                normalizedId &&
+                label &&
+                item.imageUrl &&
+                item.status !== 'coming-soon' &&
+                !item.error
+            );
+            const isUnavailablePlaceholder = Boolean(
+                normalizedId &&
+                (item.status === 'coming-soon' || item.error)
+            );
+
+            if (!isLoadable && !isUnavailablePlaceholder) return null;
+            if (seenIds.has(normalizedId)) return null;
+
+            return {
+                id: normalizedId,
+                name: label || normalizedId,
+                disabled: !isLoadable,
+                title: String(item.error || (item.status === 'coming-soon' ? 'Unavailable' : ''))
+            };
+        }
+
+        function collectNode(item) {
+            if (!item || typeof item !== 'object') return;
+
+            const selectionEntry = buildSelectionEntry(item);
+            if (selectionEntry) {
+                seenIds.add(selectionEntry.id);
+                selections.push(selectionEntry);
+            }
+
+            walk(item.children);
+        }
+
         function walk(nodes) {
             if (!Array.isArray(nodes)) return;
-            nodes.forEach((item) => {
-                if (!item || typeof item !== 'object') return;
-
-                const normalizedId = String(item.id || '').trim();
-                const label = String(item.name || normalizedId || '').trim();
-                const isLoadable = Boolean(
-                    normalizedId &&
-                    label &&
-                    item.imageUrl &&
-                    item.status !== 'coming-soon' &&
-                    !item.error
-                );
-                const isUnavailablePlaceholder = Boolean(
-                    normalizedId &&
-                    (item.status === 'coming-soon' || item.error)
-                );
-
-                if ((isLoadable || isUnavailablePlaceholder) && !seenIds.has(normalizedId)) {
-                    seenIds.add(normalizedId);
-                    selections.push({
-                        id: normalizedId,
-                        name: label || normalizedId,
-                        disabled: !isLoadable,
-                        title: String(item.error || (item.status === 'coming-soon' ? 'Unavailable' : ''))
-                    });
-                }
-
-                if (Array.isArray(item.children)) {
-                    walk(item.children);
-                }
-            });
+            nodes.forEach(collectNode);
         }
 
         walk(items);


### PR DESCRIPTION
## 🎯 What
Refactored `collectMapSelectionEntries` in `js/editor-shared.js` so traversal, node collection, and selection-entry construction are separated into smaller helpers.

## 💡 Why
This flattens the deeply nested recursive block around map selector entry collection, making duplicate handling and loadability checks easier to read without changing behavior.

## ✅ Verification
- `node --check js/editor-shared.js`
- `node tests/editor-shared.test.js`
- `node tests/file-backed-manifest-hydration.test.js`
- `git diff --check`
- `rg --files-without-match -0 "bun:test" tests/*.test.js | xargs -0 -n1 node`

Note: five Bun-specific tests were not run locally because `bun` is not installed in this environment.

## ✨ Result
The recursive walk now delegates selection eligibility and entry creation to focused helpers, preserving selector order, duplicate suppression, disabled placeholders, and child traversal.