### PR TITLE
🧹 Refactor map selection entry collection

### DIFF
--- a/js/editor-shared.js
+++ b/js/editor-shared.js
@@ -573,38 +573,39 @@
         const selections = [];
         const seenIds = new Set();
 
+        function addSelectionEntry(item) {
+            const normalizedId = String(item.id || '').trim();
+            const label = String(item.name || normalizedId || '').trim();
+            const isLoadable = Boolean(
+                normalizedId &&
+                label &&
+                item.imageUrl &&
+                item.status !== 'coming-soon' &&
+                !item.error
+            );
+            const isUnavailablePlaceholder = Boolean(
+                normalizedId &&
+                (item.status === 'coming-soon' || item.error)
+            );
+
+            if ((!isLoadable && !isUnavailablePlaceholder) || seenIds.has(normalizedId)) return;
+
+            seenIds.add(normalizedId);
+            selections.push({
+                id: normalizedId,
+                name: label || normalizedId,
+                disabled: !isLoadable,
+                title: String(item.error || (item.status === 'coming-soon' ? 'Unavailable' : ''))
+            });
+        }
+
         function walk(nodes) {
             if (!Array.isArray(nodes)) return;
             nodes.forEach((item) => {
                 if (!item || typeof item !== 'object') return;
 
-                const normalizedId = String(item.id || '').trim();
-                const label = String(item.name || normalizedId || '').trim();
-                const isLoadable = Boolean(
-                    normalizedId &&
-                    label &&
-                    item.imageUrl &&
-                    item.status !== 'coming-soon' &&
-                    !item.error
-                );
-                const isUnavailablePlaceholder = Boolean(
-                    normalizedId &&
-                    (item.status === 'coming-soon' || item.error)
-                );
-
-                if ((isLoadable || isUnavailablePlaceholder) && !seenIds.has(normalizedId)) {
-                    seenIds.add(normalizedId);
-                    selections.push({
-                        id: normalizedId,
-                        name: label || normalizedId,
-                        disabled: !isLoadable,
-                        title: String(item.error || (item.status === 'coming-soon' ? 'Unavailable' : ''))
-                    });
-                }
-
-                if (Array.isArray(item.children)) {
-                    walk(item.children);
-                }
+                addSelectionEntry(item);
+                walk(item.children);
             });
         }
 


### PR DESCRIPTION
## 🎯 What

Refactored `collectMapSelectionEntries` in `js/editor-shared.js` by extracting the selection append logic into `addSelectionEntry` and flattening child traversal through the existing `walk` array guard.

## 💡 Why

This separates traversal from loadability, placeholder, and duplicate-entry checks, making the recursive collector easier to read and maintain without changing behavior.

## ✅ Verification

- `node --check js/editor-shared.js`
- `node tests/file-backed-manifest-hydration.test.js`
- Node-compatible `tests/*.test.js` subset excluding Bun-only `bun:test` files
- `git diff --check`

Note: `node --test tests/*.test.js` is not the compatible full-suite runner in this environment; it fails on existing Bun-only tests because `bun:test` resolves to the unsupported `bun:` protocol under Node.

## ✨ Result

The selection collector now has flatter control flow and a focused helper for adding entries while preserving traversal order, duplicate suppression, disabled state, and tooltip text.