### PR TITLE
🧹 Refine theme token validation

### DIFF
--- a/js/app-config.js
+++ b/js/app-config.js
@@ -311,6 +311,7 @@
 
     const COLOR_LIKE_PATTERN = /^(#[0-9a-f]{3,8}|rgba?\([^)]+\)|hsla?\([^)]+\)|[a-z]+|var\(--[a-z0-9_-]+\)|transparent|white|black)$/i;
     const COLOR_LIKE_TOKEN_KEYWORDS = ['color', 'bg', 'ring', 'thumb', 'slider', 'text'];
+    const THEME_TOKEN_MODES = ['light', 'dark'];
 
     function isPlainObject(value) {
         return Boolean(value) && typeof value === 'object' && !Array.isArray(value);
@@ -372,7 +373,7 @@
     }
 
     function validateThemeTokens(themeTokens, errors) {
-        ['light', 'dark'].forEach((mode) => {
+        THEME_TOKEN_MODES.forEach((mode) => {
             const tokens = themeTokens[mode];
             if (!isPlainObject(tokens)) {
                 errors.push(`theme.tokens.${mode} must be an object.`);

--- a/tests/site-config.test.js
+++ b/tests/site-config.test.js
@@ -31,6 +31,11 @@ assert.notDeepStrictEqual(
     [],
     'invalid color-like theme tokens should be reported'
 );
+assert.deepEqual(
+    AppConfig.validateConfig({ theme: { tokens: { light: { '--panel-radius': 'not a valid color value' } } } }),
+    [],
+    'non-color-like theme tokens should not be color validated'
+);
 assert.notDeepStrictEqual(
     AppConfig.validateConfig({ performance: { mobileBreakpoint: 120 } }),
     [],


### PR DESCRIPTION
## 🎯 What

Named the validated theme token modes with `THEME_TOKEN_MODES` and added regression coverage for non-color-like theme token names.

## 💡 Why

The nested theme token validation block has already been extracted into helpers on current `main`; this follow-up keeps the remaining mode selection explicit and protects the helper behavior so future changes do not accidentally color-validate unrelated token names.

## ✅ Verification

- `node --check js/app-config.js`
- `node --check tests/site-config.test.js`
- `git diff --check`
- `node tests/site-config.test.js`
- `for test_file in tests/*.test.js; do if rg -q "bun:test" "$test_file"; then continue; fi; node "$test_file" || exit 1; done`

Note: attempted `npx --yes bun test tests/*.test.js` for the full Bun-inclusive suite. The sandboxed run failed on blocked npm registry access, and the elevated retry was rejected because it would download and execute third-party code outside the sandbox.

## ✨ Result

Theme token validation keeps its flattened helper flow, the validated modes are named in one place, and the test suite now documents that only color-like token keys receive color-like value validation.