### PR TITLE
🧹 Flatten file-backed map document resolution

### DIFF
--- a/js/editor-shared.js
+++ b/js/editor-shared.js
@@ -280,6 +280,39 @@
             (mapData.filterGroups && typeof mapData.filterGroups === 'object');
     }
 
+    function buildFileBackedMapCandidatePaths(fallbackMap, resolveDefaultDataUrl) {
+        const candidatePaths = [];
+        const explicitDataUrl = String(fallbackMap.dataUrl || '').trim();
+        if (explicitDataUrl) candidatePaths.push(explicitDataUrl);
+
+        const defaultDataUrl = String(resolveDefaultDataUrl(fallbackMap.id, fallbackMap) || '').trim();
+        if (defaultDataUrl && !candidatePaths.includes(defaultDataUrl)) {
+            candidatePaths.push(defaultDataUrl);
+        }
+        return candidatePaths;
+    }
+
+    function mergeFileBackedMapDocument(fallbackMap, loadedMap) {
+        if (!loadedMap || typeof loadedMap !== 'object') {
+            throw new Error('returned no JSON object');
+        }
+
+        const resolvedMap = {
+            ...fallbackMap,
+            ...cloneJson(loadedMap)
+        };
+        if (resolvedMap.selectorDescription === undefined && fallbackMap.selectorDescription !== undefined) {
+            resolvedMap.selectorDescription = fallbackMap.selectorDescription;
+        }
+        delete resolvedMap.dataUrl;
+        return resolvedMap;
+    }
+
+    async function loadFileBackedMapCandidate(candidatePath, fallbackMap, loadJsonByPath) {
+        const loadedMap = await loadJsonByPath(candidatePath, fallbackMap);
+        return mergeFileBackedMapDocument(fallbackMap, loadedMap);
+    }
+
     async function resolveFileBackedMapDocument(mapData, options = {}) {
         if (!mapData || typeof mapData !== 'object') {
             throw new Error('Cannot resolve map document: invalid map node.');
@@ -303,15 +336,7 @@
             throw new Error(`Could not resolve full map JSON for "${mapId}": no loader configured.`);
         }
 
-        const candidatePaths = [];
-        const explicitDataUrl = String(fallbackMap.dataUrl || '').trim();
-        if (explicitDataUrl) candidatePaths.push(explicitDataUrl);
-
-        const defaultDataUrl = String(resolveDefaultDataUrl(fallbackMap.id, fallbackMap) || '').trim();
-        if (defaultDataUrl && !candidatePaths.includes(defaultDataUrl)) {
-            candidatePaths.push(defaultDataUrl);
-        }
-
+        const candidatePaths = buildFileBackedMapCandidatePaths(fallbackMap, resolveDefaultDataUrl);
         if (candidatePaths.length === 0) {
             throw new Error(`Could not resolve full map JSON for "${mapId}": no dataUrl or default path was available.`);
         }
@@ -319,20 +344,7 @@
         const failures = [];
         for (const candidatePath of candidatePaths) {
             try {
-                const loadedMap = await loadJsonByPath(candidatePath, fallbackMap);
-                if (!loadedMap || typeof loadedMap !== 'object') {
-                    throw new Error('returned no JSON object');
-                }
-
-                const resolvedMap = {
-                    ...fallbackMap,
-                    ...cloneJson(loadedMap)
-                };
-                if (resolvedMap.selectorDescription === undefined && fallbackMap.selectorDescription !== undefined) {
-                    resolvedMap.selectorDescription = fallbackMap.selectorDescription;
-                }
-                delete resolvedMap.dataUrl;
-                return resolvedMap;
+                return await loadFileBackedMapCandidate(candidatePath, fallbackMap, loadJsonByPath);
             } catch (error) {
                 failures.push(`${candidatePath} (${error?.message || 'Unknown error.'})`);
             }


### PR DESCRIPTION
## 🎯 What
Refactored the deeply nested candidate-loading block in `resolveFileBackedMapDocument` into focused helpers for candidate path construction, loaded-map validation/merge, and candidate loading.

## 💡 Why
The resolver now reads as a flatter sequence of guard clauses and retry handling. This keeps the error accumulation behavior intact while making the map hydration flow easier to scan and maintain.

## ✅ Verification
- `node --check js/editor-shared.js`
- `git diff --check`
- `node tests/editor-shared.test.js`
- `node tests/file-backed-manifest-hydration.test.js`
- Ran all non-Bun JavaScript tests with `for test_file in tests/*.test.js; do if rg -q "bun:test" "$test_file"; then continue; fi; node "$test_file" || exit 1; done`

Note: a direct full `node tests/*.test.js` run is not valid for this checkout because several tests import `bun:test`, and `bun` is not installed locally.

## ✨ Result
The code-health issue is resolved without changing behavior: each fallback candidate is still tried in order, failed paths are still reported, selector descriptions are still preserved, and `dataUrl` is still removed from resolved map documents.