### PR TITLE
🧹 Flatten region checkbox counting

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -2785,6 +2785,23 @@ function setSidebarState(state, updateHash = true) {
     syncSidebarBackdropState();
 }
 
+function getRegionGroupChildCheckboxCounts(regionTypeCheckboxes, groupName) {
+    let childCount = 0;
+    let checkedChildCount = 0;
+
+    for (let i = 0; i < regionTypeCheckboxes.length; i++) {
+        const childCheckbox = regionTypeCheckboxes[i];
+        if (childCheckbox.getAttribute('data-group') !== groupName) continue;
+
+        childCount++;
+        if (childCheckbox.checked) {
+            checkedChildCount++;
+        }
+    }
+
+    return { childCount, checkedChildCount };
+}
+
 // --- Helper Function to Update the "Toggle All" Checkbox State ---
 function updateToggleAllCheckboxState() {
     if (!poiFilterCheckboxesLive) return;
@@ -2823,18 +2840,7 @@ function updateToggleAllCheckboxState() {
     // Update indeterminate state for each region group parent
     regionGroupCheckboxes.forEach(groupCheckbox => {
         const groupName = groupCheckbox.value;
-        let childCount = 0;
-        let checkedChildCount = 0;
-
-        for (let i = 0; i < regionTypeCheckboxes.length; i++) {
-            const childCheckbox = regionTypeCheckboxes[i];
-            if (childCheckbox.getAttribute('data-group') === groupName) {
-                childCount++;
-                if (childCheckbox.checked) {
-                    checkedChildCount++;
-                }
-            }
-        }
+        const { childCount, checkedChildCount } = getRegionGroupChildCheckboxCounts(regionTypeCheckboxes, groupName);
 
         if (checkedChildCount === 0) {
             groupCheckbox.checked = false;

--- a/tests/getRegionGroupChildCheckboxCounts.test.js
+++ b/tests/getRegionGroupChildCheckboxCounts.test.js
@@ -1,0 +1,47 @@
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+
+const appSource = fs.readFileSync('js/app.js', 'utf8');
+const helperStart = appSource.indexOf('function getRegionGroupChildCheckboxCounts(');
+const helperEnd = appSource.indexOf('// --- Helper Function to Update the "Toggle All" Checkbox State ---', helperStart);
+
+if (helperStart === -1 || helperEnd === -1 || helperEnd <= helperStart) {
+    throw new Error('Could not locate getRegionGroupChildCheckboxCounts in js/app.js');
+}
+
+const helperSource = appSource.slice(helperStart, helperEnd);
+let getRegionGroupChildCheckboxCounts;
+
+// eslint-disable-next-line no-eval
+eval(`getRegionGroupChildCheckboxCounts = ${helperSource}`);
+
+function createRegionTypeCheckbox(groupName, checked) {
+    return {
+        checked,
+        getAttribute(name) {
+            return name === 'data-group' ? groupName : null;
+        }
+    };
+}
+
+const regionTypeCheckboxes = [
+    createRegionTypeCheckbox('kingdoms', true),
+    createRegionTypeCheckbox('kingdoms', false),
+    createRegionTypeCheckbox('kingdoms', true),
+    createRegionTypeCheckbox('wilds', false)
+];
+
+assert.deepEqual(
+    getRegionGroupChildCheckboxCounts(regionTypeCheckboxes, 'kingdoms'),
+    { childCount: 3, checkedChildCount: 2 }
+);
+assert.deepEqual(
+    getRegionGroupChildCheckboxCounts(regionTypeCheckboxes, 'wilds'),
+    { childCount: 1, checkedChildCount: 0 }
+);
+assert.deepEqual(
+    getRegionGroupChildCheckboxCounts(regionTypeCheckboxes, 'missing'),
+    { childCount: 0, checkedChildCount: 0 }
+);
+
+console.log('getRegionGroupChildCheckboxCounts regression checks passed');


### PR DESCRIPTION
## 🎯 What

Extracted the region group child checkbox counting logic from `updateToggleAllCheckboxState()` into `getRegionGroupChildCheckboxCounts()` and replaced the deeply nested loop with a single helper call.

## 💡 Why

This makes the toggle-all state update easier to scan and keeps the parent checkbox state logic focused on applying the count result rather than collecting it inline.

## ✅ Verification

- `node --check js/app.js`
- `node --test $(for f in tests/*.test.js; do if ! grep -q "bun:test" "$f"; then printf "%s " "$f"; fi; done)` — 118 passing tests
- Added `tests/getRegionGroupChildCheckboxCounts.test.js` for the extracted helper

Note: `node --test tests/*.test.js` was also attempted, but five existing Bun-only tests import `bun:test`; `bun` is not installed in this local environment.

## ✨ Result

The previously nested child checkbox counting block is now a small named helper with guard-style control flow, preserving behavior while improving readability.