### PR TITLE
🧹 Flatten repo alias indexing

### DIFF
--- a/js/editor-shared.js
+++ b/js/editor-shared.js
@@ -363,6 +363,36 @@
         return aliases;
     }
 
+    function createNormalizedRepoEntry(entry) {
+        const normalizedPath = normalizeRepoEntryPath(entry);
+        if (!normalizedPath) return null;
+
+        return {
+            ...entry,
+            path: normalizedPath
+        };
+    }
+
+    function shouldReplaceRepoPathAlias(existingEntry, normalizedEntry) {
+        return !existingEntry || existingEntry.path.length > normalizedEntry.path.length;
+    }
+
+    function setRepoPathAlias(entryByAlias, alias, normalizedEntry) {
+        const existingEntry = entryByAlias.get(alias);
+        if (!shouldReplaceRepoPathAlias(existingEntry, normalizedEntry)) return;
+
+        entryByAlias.set(alias, normalizedEntry);
+    }
+
+    function indexRepoEntryAliases(entryByAlias, entry) {
+        const normalizedEntry = createNormalizedRepoEntry(entry);
+        if (!normalizedEntry) return;
+
+        buildRepoPathAliases(normalizedEntry.path).forEach((alias) => {
+            setRepoPathAlias(entryByAlias, alias, normalizedEntry);
+        });
+    }
+
     async function createRepoFileBackedMapSource(entries, options = {}) {
         if (!Array.isArray(entries) || entries.length === 0) {
             throw new Error('No files were provided for the repo folder.');
@@ -384,19 +414,7 @@
         const jsonCache = new Map();
 
         entries.forEach((entry) => {
-            const normalizedPath = normalizeRepoEntryPath(entry);
-            if (!normalizedPath) return;
-            const normalizedEntry = {
-                ...entry,
-                path: normalizedPath
-            };
-            const aliases = buildRepoPathAliases(normalizedPath);
-            aliases.forEach((alias) => {
-                const existingEntry = entryByAlias.get(alias);
-                if (!existingEntry || existingEntry.path.length > normalizedEntry.path.length) {
-                    entryByAlias.set(alias, normalizedEntry);
-                }
-            });
+            indexRepoEntryAliases(entryByAlias, entry);
         });
 
         function getFileEntry(relativePath) {


### PR DESCRIPTION
🎯 **What:** Refactored the repo-folder alias indexing block in `js/editor-shared.js` into small named helpers for normalized entry creation, alias replacement, and alias registration.

💡 **Why:** The previous implementation nested normalization, alias iteration, and replacement logic inside `createRepoFileBackedMapSource`. Pulling those decisions into focused helpers makes the shortest-path alias precedence rule easier to read without changing behavior.

✅ **Verification:**
- `npm install`
- `node --check js/editor-shared.js`
- `node tests/editor-shared.test.js`
- `git diff --check`
- Node-compatible suite: `for test_file in tests/*.test.js; do if rg -q "bun:test" "$test_file"; then continue; fi; node "$test_file" || exit 1; done`
- `npm pkg get scripts` returned `{}`, so there are no package lint/format scripts to run.
- Bun-specific tests were not run because `bun` is not installed in this environment: `tests/fetchJsonAsset.test.js`, `tests/buildPopupFullContent.test.js`, `tests/getMobileLayoutModeFromUrl.test.js`, `tests/sanitizeWikiLinkForHref.test.js`, `tests/refreshLucideIcons.test.js`, `tests/resolveMobileLayoutV2Enabled.test.js`.

✨ **Result:** `createRepoFileBackedMapSource` now delegates alias indexing to flatter helpers while preserving the existing alias lookup behavior.