### PR TITLE
🧹 Flatten image entry resolution

### DIFF
--- a/js/editor-shared.js
+++ b/js/editor-shared.js
@@ -363,6 +363,13 @@
         return aliases;
     }
 
+    function getRequiredMapImageUrl(mapData) {
+        const imageUrl = String(mapData?.imageUrl || '').trim();
+        if (imageUrl) return imageUrl;
+
+        throw new Error(`Map "${String(mapData?.id || mapData?.name || 'unknown-map')}" is missing an imageUrl.`);
+    }
+
     async function createRepoFileBackedMapSource(entries, options = {}) {
         if (!Array.isArray(entries) || entries.length === 0) {
             throw new Error('No files were provided for the repo folder.');
@@ -440,6 +447,10 @@
             return cloneJson(await jsonCache.get(normalizedPath));
         }
 
+        function resolveImageEntry(mapData) {
+            return getFileEntry(getRequiredMapImageUrl(mapData));
+        }
+
         const manifestDocument = await loadJsonByPath('maps/maps.json');
         const manifest = buildManifestTreeFromDocument(manifestDocument);
         if (
@@ -476,13 +487,7 @@
                 loadJsonByPath,
                 resolveDefaultDataUrl: buildDefaultMapDataUrl
             }),
-            resolveImageEntry: (mapData) => {
-                const imageUrl = String(mapData?.imageUrl || '').trim();
-                if (!imageUrl) {
-                    throw new Error(`Map "${String(mapData?.id || mapData?.name || 'unknown-map')}" is missing an imageUrl.`);
-                }
-                return getFileEntry(imageUrl);
-            }
+            resolveImageEntry
         };
     }
 

--- a/tests/editor-shared.test.js
+++ b/tests/editor-shared.test.js
@@ -651,6 +651,13 @@ assert.equal(
         /Missing required file: maps\/missing-child\.webp/
     );
 
+    assert.throws(
+        () => mapsFolderSource.resolveImageEntry({
+            id: 'missing-image-url'
+        }),
+        /Map "missing-image-url" is missing an imageUrl\./
+    );
+
     assert.deepEqual(buildManifestTreeFromFlatEntries(null), []);
     assert.deepEqual(buildManifestTreeFromFlatEntries(undefined), []);
     assert.deepEqual(buildManifestTreeFromFlatEntries({}), []);


### PR DESCRIPTION
## 🎯 What

Refactored the repo-folder map source image resolver so image URL validation lives in a named helper and the returned source object can reference a flat `resolveImageEntry` function.

## 💡 Why

This removes a deeply nested inline function from the source factory, making the validation path easier to read and safer to reuse without changing behavior.

## ✅ Verification

- `node --check js/editor-shared.js`
- `node tests/editor-shared.test.js`
- Node-compatible test sweep across `tests/*.test.js` passed; 6 Bun-only files were skipped because `bun` is not installed in this environment.

## ✨ Result

The image-entry resolution logic is flatter, named, and covered by a regression check for missing `imageUrl` errors.