### PR TITLE
🧹 Flatten map hydration cache loading

### DIFF
--- a/js/editor-shared.js
+++ b/js/editor-shared.js
@@ -502,20 +502,25 @@
             return loadPromiseCache.get(id);
         }
 
+        async function loadHydratedMapById(normalizedId) {
+            try {
+                const loadedMap = await fetchMap(normalizedId, undefined);
+                if (!loadedMap || typeof loadedMap !== 'object') {
+                    return createUnavailableMapEntry(normalizedId, `Map "${normalizedId}" returned no data.`);
+                }
+
+                return hydrateNode(loadedMap);
+            } catch (error) {
+                return createUnavailableMapEntry(normalizedId, error?.message || 'Unknown error.');
+            }
+        }
+
         async function hydrateFromId(id) {
             const normalizedId = String(id || '').trim();
             if (!normalizedId) return null;
 
             if (!cache.has(normalizedId)) {
-                cache.set(normalizedId, Promise.resolve()
-                    .then(() => fetchMap(normalizedId, undefined))
-                    .then((loadedMap) => {
-                        if (!loadedMap || typeof loadedMap !== 'object') {
-                            return createUnavailableMapEntry(normalizedId, `Map "${normalizedId}" returned no data.`);
-                        }
-                        return hydrateNode(loadedMap);
-                    })
-                    .catch((error) => createUnavailableMapEntry(normalizedId, error?.message || 'Unknown error.')));
+                cache.set(normalizedId, loadHydratedMapById(normalizedId));
             }
 
             return cloneJson(await cache.get(normalizedId));


### PR DESCRIPTION
## 🎯 What
Refactored the file-backed manifest hydration cache path in `js/editor-shared.js` by extracting the nested promise chain into a named `loadHydratedMapById` helper.

## 💡 Why
This keeps `hydrateFromId` focused on ID normalization, cache population, and cloned result return. The loading, validation, hydration, and unavailable-placeholder handling now live in a smaller function that is easier to read and maintain.

## ✅ Verification
- `node --check js/editor-shared.js`
- `node tests/editor-shared.test.js`
- `for test in tests/*.test.js; do if rg -q "bun:test" "$test"; then continue; fi; node "$test" || exit 1; done`

Bun-specific tests were not run because `bun` is not installed in this environment.

## ✨ Result
The deeply nested block at the map hydration cache insertion point is flattened without changing the caching behavior, unavailable-map fallback behavior, or cloned return behavior.