### PR TITLE
🧹 Flatten file-backed map hydration loading

### DIFF
--- a/js/editor-shared.js
+++ b/js/editor-shared.js
@@ -509,7 +509,7 @@
                     return createUnavailableMapEntry(normalizedId, `Map "${normalizedId}" returned no data.`);
                 }
 
-                return hydrateNode(loadedMap);
+                return await hydrateNode(loadedMap);
             } catch (error) {
                 return createUnavailableMapEntry(normalizedId, error?.message || 'Unknown error.');
             }

--- a/js/editor-shared.js
+++ b/js/editor-shared.js
@@ -502,20 +502,25 @@
             return loadPromiseCache.get(id);
         }
 
+        async function loadHydratedMapById(normalizedId) {
+            try {
+                const loadedMap = await fetchMap(normalizedId, undefined);
+                if (!loadedMap || typeof loadedMap !== 'object') {
+                    return createUnavailableMapEntry(normalizedId, `Map "${normalizedId}" returned no data.`);
+                }
+
+                return hydrateNode(loadedMap);
+            } catch (error) {
+                return createUnavailableMapEntry(normalizedId, error?.message || 'Unknown error.');
+            }
+        }
+
         async function hydrateFromId(id) {
             const normalizedId = String(id || '').trim();
             if (!normalizedId) return null;
 
             if (!cache.has(normalizedId)) {
-                cache.set(normalizedId, Promise.resolve()
-                    .then(() => fetchMap(normalizedId, undefined))
-                    .then((loadedMap) => {
-                        if (!loadedMap || typeof loadedMap !== 'object') {
-                            return createUnavailableMapEntry(normalizedId, `Map "${normalizedId}" returned no data.`);
-                        }
-                        return hydrateNode(loadedMap);
-                    })
-                    .catch((error) => createUnavailableMapEntry(normalizedId, error?.message || 'Unknown error.')));
+                cache.set(normalizedId, loadHydratedMapById(normalizedId));
             }
 
             return cloneJson(await cache.get(normalizedId));

--- a/tests/file-backed-manifest-hydration.test.js
+++ b/tests/file-backed-manifest-hydration.test.js
@@ -95,6 +95,24 @@ const {
     assert.equal(loadCounts.get('castgate'), 1);
     assert.equal(loadCounts.get('BrokenMap'), 1);
 
+    const hydrationFailureTree = await hydrateFileBackedManifestTree(
+        ['BadDataUrl'],
+        async () => ({
+            id: 'BadDataUrl',
+            name: 'Bad Data URL',
+            imageUrl: 'maps/bad-data-url.webp'
+        }),
+        {
+            resolveDataUrl: () => {
+                throw new Error('Could not resolve data URL');
+            }
+        }
+    );
+    const hydrationFailureMap = findMapRecursive(hydrationFailureTree, 'BadDataUrl');
+    assert.ok(hydrationFailureMap);
+    assert.equal(hydrationFailureMap.status, 'coming-soon');
+    assert.match(hydrationFailureMap.error, /Could not resolve data URL/);
+
     console.log('file-backed manifest hydration regression checks passed');
 })().catch((error) => {
     console.error(error);


### PR DESCRIPTION
## 🎯 What
Refactored the file-backed manifest hydration path in `js/editor-shared.js` by extracting the nested map loading and fallback handling from `hydrateFromId` into `loadHydratedMapById`.

## 💡 Why
The hydration routine already has several responsibilities: cache lookup, map loading, unavailable-map fallback creation, recursive hydration, and cloning. Moving the loading/error branch into a named helper keeps `hydrateFromId` focused on ID normalization and cache use, making the control flow flatter and easier to maintain without changing behavior.

## ✅ Verification
- `node --check js/editor-shared.js`
- `node tests/file-backed-manifest-hydration.test.js`
- `node tests/editor-shared.test.js`
- `node tests/file-backed-map-parity.test.js`
- `node tests/generate-atlas-index-file-backed.test.js`
- Attempted `node --test tests/*.test.js`: Node-compatible tests passed, but six Bun-specific tests could not run under Node because they import `bun:test`; `bun` is not installed in this environment.

## ✨ Result
The file-backed hydration code now uses a small async helper with direct `await`/`try` flow instead of an inline nested promise chain, preserving the existing cache semantics and unavailable-map fallback behavior.