### PR TITLE
🧪 [Testing Improvement] Add tests for drainPrefetchImageQueue

### DIFF
--- a/tests/drainPrefetchImageQueue.test.js
+++ b/tests/drainPrefetchImageQueue.test.js
@@ -1,0 +1,125 @@
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+
+const appSource = fs.readFileSync('js/app.js', 'utf8');
+
+function extractFunctionSource(name) {
+    const start = appSource.indexOf(`function ${name}(`);
+    if (start === -1) {
+        throw new Error(`Could not find function ${name}`);
+    }
+
+    let depth = 0;
+    let end = -1;
+    for (let i = start; i < appSource.length; i += 1) {
+        const char = appSource[i];
+        if (char === '{') depth += 1;
+        if (char === '}') {
+            depth -= 1;
+            if (depth === 0) {
+                end = i + 1;
+                break;
+            }
+        }
+    }
+
+    if (end === -1) {
+        throw new Error(`Could not parse function ${name}`);
+    }
+
+    return appSource.slice(start, end);
+}
+
+let prefetchImageInFlight = false;
+let prefetchImageQueue = [];
+let prefetchedImageUrls = new Set();
+let mockImageInstances = [];
+
+global.Image = class {
+    constructor() {
+        this.onload = null;
+        this.onerror = null;
+        this.src = '';
+        mockImageInstances.push(this);
+    }
+};
+
+let drainPrefetchImageQueue;
+// eslint-disable-next-line no-eval
+eval(`drainPrefetchImageQueue = ${extractFunctionSource('drainPrefetchImageQueue')}`);
+
+function resetState() {
+    prefetchImageInFlight = false;
+    prefetchImageQueue = [];
+    prefetchedImageUrls.clear();
+    mockImageInstances = [];
+}
+
+// 1. Should return early if an image is already in flight
+resetState();
+prefetchImageInFlight = true;
+prefetchImageQueue = ['url1'];
+drainPrefetchImageQueue();
+assert.equal(mockImageInstances.length, 0);
+assert.equal(prefetchImageQueue.length, 1);
+
+// 2. Should return early if the queue is empty
+resetState();
+drainPrefetchImageQueue();
+assert.equal(mockImageInstances.length, 0);
+
+// 3. Should process the next URL in the queue
+resetState();
+prefetchImageQueue = ['url1', 'url2'];
+drainPrefetchImageQueue();
+assert.equal(prefetchImageInFlight, true);
+assert.equal(prefetchImageQueue.length, 1);
+assert.equal(prefetchImageQueue[0], 'url2');
+assert.equal(mockImageInstances.length, 1);
+assert.equal(mockImageInstances[0].src, 'url1');
+
+// 4. Should process the next URL when the image loads
+resetState();
+prefetchImageQueue = ['url1', 'url2'];
+drainPrefetchImageQueue();
+assert.equal(mockImageInstances.length, 1);
+assert.equal(prefetchImageInFlight, true);
+
+// Trigger onload
+mockImageInstances[0].onload();
+
+assert.equal(mockImageInstances.length, 2);
+assert.equal(mockImageInstances[1].src, 'url2');
+assert.equal(prefetchImageInFlight, true);
+assert.equal(prefetchImageQueue.length, 0);
+
+// Trigger onload for second image
+mockImageInstances[1].onload();
+assert.equal(prefetchImageInFlight, false);
+
+// 5. Should handle image load errors by deleting from prefetchedImageUrls and processing the next URL
+resetState();
+prefetchImageQueue = ['url1', 'url2'];
+prefetchedImageUrls.add('url1');
+prefetchedImageUrls.add('url2');
+drainPrefetchImageQueue();
+
+assert.equal(mockImageInstances.length, 1);
+assert.equal(prefetchImageInFlight, true);
+
+// Trigger onerror
+mockImageInstances[0].onerror();
+
+assert.equal(prefetchedImageUrls.has('url1'), false);
+assert.equal(prefetchedImageUrls.has('url2'), true);
+assert.equal(mockImageInstances.length, 2);
+assert.equal(mockImageInstances[1].src, 'url2');
+
+// 6. Should return if nextUrl is empty
+resetState();
+prefetchImageQueue = [undefined, 'url2'];
+drainPrefetchImageQueue();
+assert.equal(prefetchImageInFlight, false);
+assert.equal(mockImageInstances.length, 0);
+
+console.log('drainPrefetchImageQueue behavior tests passed');


### PR DESCRIPTION
🎯 **What:** 
The application's `drainPrefetchImageQueue` was lacking tests. This function is responsible for sequentially preloading linked map images. The missing tests left an important mechanism vulnerable to regressions.

📊 **Coverage:**
The added tests cover all logical paths in `drainPrefetchImageQueue`:
1. Returns early if an image is already in-flight.
2. Returns early if the `prefetchImageQueue` is empty.
3. Sets `prefetchImageInFlight` to true and creates an `Image` instance pulling the URL from the queue.
4. Simulates `onload` which successfully resets the in-flight flag and recursively processes the next item.
5. Simulates `onerror` which handles cleanup (removing the item from the tracking set) before continuing to process the queue.
6. Handles empty/falsy `nextUrl` correctly.

✨ **Result:**
The test coverage for `drainPrefetchImageQueue` is vastly improved and catches regressions across both success (`onload`) and failure (`onerror`) paths. Tests assert flawlessly alongside the existing evaluation pattern used by the codebase.

---
*PR created automatically by Jules for task [12920100701795858514](https://jules.google.com/task/12920100701795858514) started by @jaxsnjohnson*