### PR TITLE
🧪 [testing improvement] Add tests for getMapDataUrl

### DIFF
--- a/tests/getMapDataUrl.test.js
+++ b/tests/getMapDataUrl.test.js
@@ -1,0 +1,41 @@
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+
+const appSource = fs.readFileSync('js/app.js', 'utf8');
+const fnStart = appSource.indexOf('function getMapDataUrl(mapEntry) {');
+const fnEnd = appSource.indexOf('async function getMapDefinition(mapId, preResolvedMap = null) {');
+
+if (fnStart === -1 || fnEnd === -1 || fnEnd <= fnStart) {
+    throw new Error('Could not locate getMapDataUrl function block in js/app.js');
+}
+
+const fnSource = appSource.slice(fnStart, fnEnd);
+// Evaluate production source so assertions stay coupled to real logic.
+// eslint-disable-next-line no-eval
+eval(fnSource);
+
+// Test explicit dataUrl
+assert.equal(getMapDataUrl({ dataUrl: 'custom/path.json' }), 'custom/path.json');
+
+// Test explicit dataUrl with whitespace (should fallback to id if empty after trim)
+assert.equal(getMapDataUrl({ dataUrl: '   ', id: 'fallback-id' }), 'maps/fallback-id.json');
+assert.equal(getMapDataUrl({ dataUrl: '  custom/path.json  ' }), 'custom/path.json');
+
+// Test no dataUrl, valid id
+assert.equal(getMapDataUrl({ id: 'my-map-id' }), 'maps/my-map-id.json');
+
+// Test id with whitespace
+assert.equal(getMapDataUrl({ id: '  my-map-id  ' }), 'maps/my-map-id.json');
+
+// Test no dataUrl, empty id
+assert.equal(getMapDataUrl({ id: '' }), '');
+assert.equal(getMapDataUrl({ id: '   ' }), '');
+
+// Test completely empty object
+assert.equal(getMapDataUrl({}), '');
+
+// Test null/undefined
+assert.equal(getMapDataUrl(null), '');
+assert.equal(getMapDataUrl(undefined), '');
+
+console.log('getMapDataUrl regression checks passed');


### PR DESCRIPTION
🎯 **What:** The `getMapDataUrl` function lacked testing coverage for its map data URL resolution logic.
📊 **Coverage:** Added test cases to cover explicit data URLs, fallback to ID-based paths, whitespace handling and trimming, as well as handling for empty, null, and undefined `mapEntry` inputs.
✨ **Result:** Improved test coverage and reliability for map definition data URL resolution without regressions.

---
*PR created automatically by Jules for task [14605760582889505060](https://jules.google.com/task/14605760582889505060) started by @jaxsnjohnson*