### PR TITLE
🧪 [testing improvement] Add test for isRenderableMapEntry

### DIFF
--- a/tests/isRenderableMapEntry.test.js
+++ b/tests/isRenderableMapEntry.test.js
@@ -1,0 +1,52 @@
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+
+const appSource = fs.readFileSync('js/app.js', 'utf8');
+const fnStart = appSource.indexOf('function isRenderableMapEntry(item) {');
+const fnEnd = appSource.indexOf('function findFirstLoadableIdRecursive(items) {');
+
+if (fnStart === -1 || fnEnd === -1 || fnEnd <= fnStart) {
+    throw new Error('Could not locate isRenderableMapEntry function block in js/app.js');
+}
+
+const fnSource = appSource.slice(fnStart, fnEnd);
+// Evaluate production source so assertions stay coupled to real logic.
+// eslint-disable-next-line no-eval
+eval(fnSource);
+
+// Valid item
+assert.equal(isRenderableMapEntry({ id: 'map1', width: 800, height: 600, imageUrl: 'maps/map1.webp' }), true);
+assert.equal(isRenderableMapEntry({ id: 'map1', width: '800', height: '600', imageUrl: ' maps/map1.webp ' }), true);
+
+// Invalid type
+assert.equal(isRenderableMapEntry(null), false);
+assert.equal(isRenderableMapEntry(undefined), false);
+assert.equal(isRenderableMapEntry('string'), false);
+assert.equal(isRenderableMapEntry(123), false);
+
+// Status coming-soon
+assert.equal(isRenderableMapEntry({ id: 'map1', status: 'coming-soon', width: 800, height: 600, imageUrl: 'maps/map1.webp' }), false);
+
+// Missing or empty ID
+assert.equal(isRenderableMapEntry({ width: 800, height: 600, imageUrl: 'maps/map1.webp' }), false);
+assert.equal(isRenderableMapEntry({ id: '', width: 800, height: 600, imageUrl: 'maps/map1.webp' }), false);
+assert.equal(isRenderableMapEntry({ id: '   ', width: 800, height: 600, imageUrl: 'maps/map1.webp' }), false);
+
+// Invalid width
+assert.equal(isRenderableMapEntry({ id: 'map1', width: 0, height: 600, imageUrl: 'maps/map1.webp' }), false);
+assert.equal(isRenderableMapEntry({ id: 'map1', width: -10, height: 600, imageUrl: 'maps/map1.webp' }), false);
+assert.equal(isRenderableMapEntry({ id: 'map1', width: NaN, height: 600, imageUrl: 'maps/map1.webp' }), false);
+assert.equal(isRenderableMapEntry({ id: 'map1', height: 600, imageUrl: 'maps/map1.webp' }), false); // missing width
+
+// Invalid height
+assert.equal(isRenderableMapEntry({ id: 'map1', width: 800, height: 0, imageUrl: 'maps/map1.webp' }), false);
+assert.equal(isRenderableMapEntry({ id: 'map1', width: 800, height: -10, imageUrl: 'maps/map1.webp' }), false);
+assert.equal(isRenderableMapEntry({ id: 'map1', width: 800, height: NaN, imageUrl: 'maps/map1.webp' }), false);
+assert.equal(isRenderableMapEntry({ id: 'map1', width: 800, imageUrl: 'maps/map1.webp' }), false); // missing height
+
+// Missing or empty imageUrl
+assert.equal(isRenderableMapEntry({ id: 'map1', width: 800, height: 600 }), false);
+assert.equal(isRenderableMapEntry({ id: 'map1', width: 800, height: 600, imageUrl: '' }), false);
+assert.equal(isRenderableMapEntry({ id: 'map1', width: 800, height: 600, imageUrl: '   ' }), false);
+
+console.log('isRenderableMapEntry tests passed');


### PR DESCRIPTION
🎯 **What:** The `isRenderableMapEntry` function within `js/app.js` lacked test coverage, allowing for silent regressions around map rendering capabilities and fallback cases.
📊 **Coverage:** A test file `tests/isRenderableMapEntry.test.js` was introduced utilizing our standard CommonJS `eval` extraction approach to test valid map entries, missing attributes, zero-dimensions, null safety, and `coming-soon` status entries.
✨ **Result:** A major piece of the map-selection pipeline is now safely guarded against regressions with clear, focused, deterministic Node assertions.

---
*PR created automatically by Jules for task [10035417632240031078](https://jules.google.com/task/10035417632240031078) started by @jaxsnjohnson*