### PR TITLE
🧹 Remove unused variable multiPointSegmentTooltips

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -147,7 +147,6 @@ let isMeasuringMultiPoint = false; // Tracks if multi-point mode is active
 let multiPointPath = []; // Array of L.LatLng objects for the current path
 let multiPointPolyline = null; // The L.Polyline layer for the drawn path
 let multiPointVertexMarkers = []; // Array of L.CircleMarker for vertices
-let multiPointSegmentTooltips = []; // Array of L.Tooltip for segment lengths (optional)
 let multiPointTotalTooltip = null; // L.Tooltip for the total path length
 let temporaryMouseMoveLine = null; // L.Polyline for the line from last point to cursor
 let temporaryMouseMoveTooltip = null; // L.Tooltip for the temporary line's length


### PR DESCRIPTION
🎯 **What:** Removed the unused `multiPointSegmentTooltips` variable declaration from `js/app.js`.
💡 **Why:** The variable was marked as unused by ESLint and was not utilized anywhere in the codebase. Removing it cleans up the state variables.
✅ **Verification:** Ran `npm run test` and `npm run test:unit` to ensure no functionality is broken. Cleaned up build artifacts to ensure the commit only contains the intended source file changes.
✨ **Result:** Improved code cleanliness and maintainability by removing unused dead code.

---
*PR created automatically by Jules for task [18407458220215020874](https://jules.google.com/task/18407458220215020874) started by @jaxsnjohnson*