### PR TITLE
🧹 Sentinel: Remove unused lockedCoords variable

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -657,7 +657,6 @@ let currentSidebarState = 'o';
 let markersVisible = true; // <--- THIS SHOULD BE TRUE FOR VISIBLE BY DEFAULT
 let currentLatLonBounds = null;
 let coordsLocked = false;
-let lockedCoords = null;
 const transitionDuration = 300; // ms for sidebar animation
 let filtersPanelVisible = false; // State for combined filter panel visibility
 
@@ -6156,7 +6155,6 @@ function updateCoordinates(e) {
     if (!currentLatLonBounds || !currentBounds) return;
 
     const { lat, lon } = projectMapPointToLatLon(e.latlng, currentLatLonBounds, currentBounds);
-    lockedCoords = { lat, lon };
     updateCoordinateDisplay(lat, lon);
 }
 

--- a/tests/updateCoordinates.test.js
+++ b/tests/updateCoordinates.test.js
@@ -1,78 +1,118 @@
 const assert = require('node:assert/strict');
 const fs = require('node:fs');
+const vm = require('node:vm');
 
-// Extract the updateCoordinates helper from production source.
 const appSource = fs.readFileSync('js/app.js', 'utf8');
-const fnStart = appSource.indexOf('function getMapPixelDimensions(');
-const fnEnd = appSource.indexOf('// --- Map Click Handler ---');
 
-if (fnStart === -1 || fnEnd === -1 || fnEnd <= fnStart) {
-    throw new Error('Could not locate coordinate helper function block in js/app.js');
+const sandbox = {
+    coordsLocked: false,
+    currentLatLonBounds: {
+        north: 73,
+        south: 1.24,
+        east: -48.34375,
+        west: 71.65625
+    },
+    currentBounds: [[0, 0], [6144, 8192]],
+    updateCoordinateDisplay: () => {}, // Mocked below
+    console,
+    Math,
+    Object,
+    Array,
+    String,
+    Number,
+    Boolean
+};
+
+// Extract functions securely without relying on strict formatting.
+const functionNames = [
+    'getMapPixelDimensions',
+    'projectMapPointToLatLon',
+    'updateCoordinates'
+];
+
+let extractedCode = '';
+for (const fnName of functionNames) {
+    const fnRegex = new RegExp(`function\\s+${fnName}\\s*\\([\\s\\S]*?\\)\\s*{`);
+    const match = appSource.match(fnRegex);
+    if (!match) throw new Error(`Could not find function ${fnName}`);
+
+    let startIndex = match.index;
+    let braceCount = 0;
+    let inString = false;
+    let stringChar = '';
+    let endIndex = startIndex;
+
+    // Find the matching closing brace
+    for (let i = startIndex; i < appSource.length; i++) {
+        const char = appSource[i];
+        const prevChar = i > 0 ? appSource[i-1] : '';
+
+        if (!inString && (char === "'" || char === '"' || char === '`')) {
+            inString = true;
+            stringChar = char;
+        } else if (inString && char === stringChar && prevChar !== '\\') {
+            inString = false;
+        } else if (!inString) {
+            if (char === '{') braceCount++;
+            else if (char === '}') {
+                braceCount--;
+                if (braceCount === 0) {
+                    endIndex = i + 1;
+                    break;
+                }
+            }
+        }
+    }
+    extractedCode += appSource.slice(startIndex, endIndex) + '\n\n';
 }
 
-const fnSource = appSource.slice(fnStart, fnEnd);
-
-// Set up the globals the function expects.
-global.coordsLocked = false;
-global.currentLatLonBounds = {
-    north: 73,
-    south: 1.24,
-    east: -48.34375,
-    west: 71.65625
-};
-// currentBounds is [[yMin, xMin], [yMax, xMax]] where y measures pixel height.
-global.currentBounds = [[0, 0], [6144, 8192]];
+vm.createContext(sandbox);
+vm.runInContext(extractedCode, sandbox);
 
 let lastLatLon = null;
-global.lockedCoords = null;
-global.updateCoordinateDisplay = (lat, lon) => {
+sandbox.updateCoordinateDisplay = (lat, lon) => {
     lastLatLon = { lat, lon };
 };
+
 const assertClose = (actual, expected, epsilon = 1e-9) => {
     assert.ok(Math.abs(actual - expected) <= epsilon, `Expected ${actual} to be within ${epsilon} of ${expected}`);
 };
 
-// eslint-disable-next-line no-eval
-eval(fnSource);
-
 // Top-left corner should map to the northern & western bounds.
-// CRS.Simple uses lat=mapHeight at the top edge.
-updateCoordinates({ latlng: { lat: 6144, lng: 0 } });
+sandbox.updateCoordinates({ latlng: { lat: 6144, lng: 0 } });
 assertClose(lastLatLon.lat, 73);
 assertClose(lastLatLon.lon, 71.65625);
 
 // Bottom-right corner should map to the southern & eastern bounds.
-updateCoordinates({ latlng: { lat: 0, lng: 8192 } });
+sandbox.updateCoordinates({ latlng: { lat: 0, lng: 8192 } });
 assertClose(lastLatLon.lat, 1.24);
 assertClose(lastLatLon.lon, -48.34375);
 
 // Midpoint should be halfway between bounds.
-updateCoordinates({ latlng: { lat: 3072, lng: 4096 } });
+sandbox.updateCoordinates({ latlng: { lat: 3072, lng: 4096 } });
 assertClose(lastLatLon.lat, 37.120000000000005);
 assertClose(lastLatLon.lon, 11.65625);
 
 // The pure projection helper should preserve the same interpolation semantics.
-const projected = projectMapPointToLatLon(
+const projected = sandbox.projectMapPointToLatLon(
     { lat: 1536, lng: 2048 },
-    currentLatLonBounds,
-    currentBounds
+    sandbox.currentLatLonBounds,
+    sandbox.currentBounds
 );
 assertClose(projected.lat, 19.18);
 assertClose(projected.lon, 41.65625);
 
 // Locked coordinates should prevent hover updates from mutating state.
-coordsLocked = true;
+sandbox.coordsLocked = true;
 lastLatLon = null;
-lockedCoords = { lat: 37.12, lon: 11.65625 };
-updateCoordinates({ latlng: { lat: 0, lng: 0 } });
+sandbox.updateCoordinates({ latlng: { lat: 0, lng: 0 } });
 assert.equal(lastLatLon, null);
-assert.deepEqual(lockedCoords, { lat: 37.12, lon: 11.65625 });
 
 // Missing bounds should no-op instead of throwing.
-coordsLocked = false;
-currentBounds = null;
+sandbox.coordsLocked = false;
+sandbox.currentBounds = null;
 lastLatLon = null;
-updateCoordinates({ latlng: { lat: 0, lng: 0 } });
+sandbox.updateCoordinates({ latlng: { lat: 0, lng: 0 } });
 assert.equal(lastLatLon, null);
 
 console.log('updateCoordinates regression checks passed');


### PR DESCRIPTION
🎯 **What:** Removed the unused `lockedCoords` variable from `js/app.js` and refactored its unit test (`tests/updateCoordinates.test.js`) to use `vm.runInContext` instead of the brittle `indexOf`/`eval` extraction pattern.
💡 **Why:** The variable was assigned but never read, causing an ESLint unused variable warning. Additionally, the unit test utilized a string slicing extraction pattern which fails code reviews and pollutes the global scope.
✅ **Verification:** Ran `pnpm run test:unit tests/updateCoordinates.test.js` and full suite validation via `pnpm run test` locally to ensure no regressions. Cleaned up build artifacts in `dist/` and `maps/` prior to commit.
✨ **Result:** Improved code health by removing dead code and significantly modernizing the safety and reliability of the associated test.

---
*PR created automatically by Jules for task [9983633550466006892](https://jules.google.com/task/9983633550466006892) started by @jaxsnjohnson*