### PR TITLE
🧹 Remove unused MOBILE_PANEL_MARGIN constant in js/app.js

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -82,7 +82,6 @@ const MOBILE_TOOLS_PANEL_GM = 'gm';
 const MOBILE_LAYOUT_QUERY_PARAM = 'mobileLayout';
 const MOBILE_LAYOUT_MODE_V2 = 'v2';
 const MOBILE_LAYOUT_MODE_LEGACY = 'legacy';
-const MOBILE_PANEL_MARGIN = 10;
 
 if (typeof document !== 'undefined') {
     document.documentElement.classList.toggle('is-firefox', isFirefox);


### PR DESCRIPTION
🎯 **What:** Removed the unused `MOBILE_PANEL_MARGIN` constant from `js/app.js`.
💡 **Why:** The constant is marked as unused by ESLint. Removing it is a simple code cleanup that improves the maintainability and readability of the codebase.
✅ **Verification:** Verified the removal using `git diff` and ran the full test suite (`pnpm run test`) to ensure no functionality was broken.
✨ **Result:** A cleaner codebase without dead code.

---
*PR created automatically by Jules for task [393865638977425076](https://jules.google.com/task/393865638977425076) started by @jaxsnjohnson*