### PR TITLE
🧹 Refactor repo file-backed map source

### DIFF
--- a/js/editor-shared.js
+++ b/js/editor-shared.js
@@ -435,55 +435,64 @@
         });
     }
 
-    async function createRepoFileBackedMapSource(entries, options = {}) {
+    function assertRepoFileEntries(entries) {
         if (!Array.isArray(entries) || entries.length === 0) {
             throw new Error('No files were provided for the repo folder.');
         }
+    }
 
-        const readText = typeof options.readText === 'function'
-            ? options.readText
-            : async (entry) => {
-                if (!entry || typeof entry !== 'object') {
-                    throw new Error('Missing repo file entry.');
-                }
-                if (typeof entry.text === 'string') return entry.text;
-                if (typeof entry.text === 'function') return entry.text();
-                if (entry.file && typeof entry.file.text === 'function') return entry.file.text();
-                throw new Error(`Could not read "${normalizeRepoEntryPath(entry)}".`);
-            };
+    function createRepoEntryTextReader(options = {}) {
+        if (typeof options.readText === 'function') return options.readText;
 
+        return async (entry) => {
+            if (!entry || typeof entry !== 'object') {
+                throw new Error('Missing repo file entry.');
+            }
+            if (typeof entry.text === 'string') return entry.text;
+            if (typeof entry.text === 'function') return entry.text();
+            if (entry.file && typeof entry.file.text === 'function') return entry.file.text();
+            throw new Error(`Could not read "${normalizeRepoEntryPath(entry)}".`);
+        };
+    }
+
+    function buildRepoEntryAliasIndex(entries) {
         const entryByAlias = new Map();
-        const jsonCache = new Map();
 
         entries.forEach((entry) => {
             indexRepoEntryAliases(entryByAlias, entry);
         });
 
-        function getFileEntry(relativePath) {
-            const normalizedPath = String(relativePath || '')
-                .replace(/\\/g, '/')
-                .replace(/^\.?\//, '')
-                .replace(/\/+/g, '/')
-                .trim();
-            if (!normalizedPath) {
-                throw new Error('Missing required file path.');
-            }
+        return entryByAlias;
+    }
+
+    function normalizeRepoLookupPath(relativePath, missingPathMessage) {
+        const normalizedPath = String(relativePath || '')
+            .replace(/\\/g, '/')
+            .replace(/^\.?\//, '')
+            .replace(/\/+/g, '/')
+            .trim();
+        if (!normalizedPath) {
+            throw new Error(missingPathMessage);
+        }
+        return normalizedPath;
+    }
+
+    function createRepoFileResolver(entryByAlias) {
+        return function getFileEntry(relativePath) {
+            const normalizedPath = normalizeRepoLookupPath(relativePath, 'Missing required file path.');
             const entry = entryByAlias.get(normalizedPath);
             if (!entry) {
                 throw new Error(`Missing required file: ${normalizedPath}`);
             }
             return entry;
-        }
+        };
+    }
 
-        async function loadJsonByPath(relativePath) {
-            const normalizedPath = String(relativePath || '')
-                .replace(/\\/g, '/')
-                .replace(/^\.?\//, '')
-                .replace(/\/+/g, '/')
-                .trim();
-            if (!normalizedPath) {
-                throw new Error('Missing JSON file path.');
-            }
+    function createRepoJsonLoader(getFileEntry, readText) {
+        const jsonCache = new Map();
+
+        return async function loadJsonByPath(relativePath) {
+            const normalizedPath = normalizeRepoLookupPath(relativePath, 'Missing JSON file path.');
 
             if (!jsonCache.has(normalizedPath)) {
                 jsonCache.set(normalizedPath, Promise.resolve().then(async () => {
@@ -498,49 +507,72 @@
             }
 
             return cloneJson(await jsonCache.get(normalizedPath));
-        }
+        };
+    }
 
-        function resolveImageEntry(mapData) {
-            return getFileEntry(getRequiredMapImageUrl(mapData));
-        }
-
-        const manifestDocument = await loadJsonByPath('maps/maps.json');
-        const manifest = buildManifestTreeFromDocument(manifestDocument);
+    function assertRepoManifestDocument(manifestDocument, manifest) {
         if (
             (!Array.isArray(manifestDocument?.maps) && !Array.isArray(manifestDocument)) ||
             manifest.length === 0
         ) {
             throw new Error('maps/maps.json must contain manifest entries.');
         }
+    }
 
-        let browseTree;
+    async function loadRepoManifestTree(loadJsonByPath) {
+        const manifestDocument = await loadJsonByPath('maps/maps.json');
+        const manifest = buildManifestTreeFromDocument(manifestDocument);
+        assertRepoManifestDocument(manifestDocument, manifest);
+        return manifest;
+    }
+
+    function resolveRepoManifestDataUrl(mapId, manifestNode) {
+        return String(manifestNode?.dataUrl || buildDefaultMapDataUrl(mapId)).trim();
+    }
+
+    async function hydrateRepoBrowseTreeFromManifest(manifest, loadJsonByPath) {
+        return hydrateFileBackedManifestTree(
+            manifest,
+            async (mapId, manifestNode) => loadJsonByPath(resolveRepoManifestDataUrl(mapId, manifestNode)),
+            {
+                resolveDataUrl: resolveRepoManifestDataUrl
+            }
+        );
+    }
+
+    async function loadRepoBrowseTree(manifest, loadJsonByPath) {
         try {
             const atlas = await loadJsonByPath('maps/atlas-index.json');
-            browseTree = normalizeManifestTree(Array.isArray(atlas?.tree) ? atlas.tree : []);
+            return normalizeManifestTree(Array.isArray(atlas?.tree) ? atlas.tree : []);
         } catch (error) {
-            browseTree = await hydrateFileBackedManifestTree(
-                manifest,
-                async (mapId, manifestNode) => loadJsonByPath(
-                    String(manifestNode?.dataUrl || buildDefaultMapDataUrl(mapId)).trim()
-                ),
-                {
-                    resolveDataUrl: (mapId, manifestNode) => String(
-                        manifestNode?.dataUrl || buildDefaultMapDataUrl(mapId)
-                    ).trim()
-                }
-            );
+            return hydrateRepoBrowseTreeFromManifest(manifest, loadJsonByPath);
         }
+    }
+
+    function createRepoMapDocumentResolver(loadJsonByPath) {
+        return (mapData) => resolveFileBackedMapDocument(mapData, {
+            loadJsonByPath,
+            resolveDefaultDataUrl: buildDefaultMapDataUrl
+        });
+    }
+
+    async function createRepoFileBackedMapSource(entries, options = {}) {
+        assertRepoFileEntries(entries);
+
+        const readText = createRepoEntryTextReader(options);
+        const entryByAlias = buildRepoEntryAliasIndex(entries);
+        const getFileEntry = createRepoFileResolver(entryByAlias);
+        const loadJsonByPath = createRepoJsonLoader(getFileEntry, readText);
+        const manifest = await loadRepoManifestTree(loadJsonByPath);
+        const browseTree = await loadRepoBrowseTree(manifest, loadJsonByPath);
 
         return {
             kind: 'repo-folder',
             baseManifest: normalizeManifestTree(manifest),
             browseTree,
             loadJsonByPath,
-            resolveMapDocument: (mapData) => resolveFileBackedMapDocument(mapData, {
-                loadJsonByPath,
-                resolveDefaultDataUrl: buildDefaultMapDataUrl
-            }),
-            resolveImageEntry
+            resolveMapDocument: createRepoMapDocumentResolver(loadJsonByPath),
+            resolveImageEntry: (mapData) => getFileEntry(getRequiredMapImageUrl(mapData))
         };
     }
 

--- a/tests/editor-shared.test.js
+++ b/tests/editor-shared.test.js
@@ -703,6 +703,55 @@ assert.equal(
         /Map "missing-image-url" is missing an imageUrl\./
     );
 
+    const repoReadCounts = new Map();
+    const cachedJsonSource = await createRepoFileBackedMapSource([
+        {
+            path: 'maps/maps.json',
+            text: JSON.stringify([
+                {
+                    id: 'cached-map',
+                    order: 0,
+                    dataUrl: 'maps/cached-map.json'
+                }
+            ])
+        },
+        {
+            path: 'maps/atlas-index.json',
+            text: JSON.stringify({
+                tree: [
+                    {
+                        id: 'cached-map',
+                        name: 'Cached Map',
+                        imageUrl: 'maps/cached-map.webp',
+                        dataUrl: 'maps/cached-map.json'
+                    }
+                ]
+            })
+        },
+        {
+            path: 'maps/cached-map.json',
+            text: JSON.stringify({
+                id: 'cached-map',
+                name: 'Cached Map',
+                imageUrl: 'maps/cached-map.webp'
+            })
+        },
+        {
+            path: 'maps/cached-map.webp',
+            text: 'unused'
+        }
+    ], {
+        readText: async (entry) => {
+            repoReadCounts.set(entry.path, (repoReadCounts.get(entry.path) || 0) + 1);
+            return entry.text;
+        }
+    });
+    const firstCachedMap = await cachedJsonSource.loadJsonByPath('maps/cached-map.json');
+    firstCachedMap.name = 'Mutated Map';
+    const secondCachedMap = await cachedJsonSource.loadJsonByPath('./maps/cached-map.json');
+    assert.equal(secondCachedMap.name, 'Cached Map');
+    assert.equal(repoReadCounts.get('maps/cached-map.json'), 1);
+
     assert.deepEqual(buildManifestTreeFromFlatEntries(null), []);
     assert.deepEqual(buildManifestTreeFromFlatEntries(undefined), []);
     assert.deepEqual(buildManifestTreeFromFlatEntries({}), []);


### PR DESCRIPTION
## 🎯 What
Refactors `createRepoFileBackedMapSource` in `js/editor-shared.js` into smaller helpers for repo entry validation, text reading, alias indexing, path normalization, JSON loading, manifest loading, browse-tree fallback hydration, and map document resolution.

Adds focused regression coverage for the extracted JSON loader behavior so normalized paths still share cached reads while callers still receive cloned JSON documents.

## 💡 Why
`createRepoFileBackedMapSource` previously mixed file lookup setup, JSON caching, manifest validation, atlas loading, fallback hydration, and public API construction in one async function. Splitting those responsibilities makes the repo-folder map source easier to scan and safer to change without changing its behavior.

## ✅ Verification
- `node tests/editor-shared.test.js`
- `npm run test:unit`
- `node --check js/editor-shared.js`
- `git diff --check -- js/editor-shared.js tests/editor-shared.test.js`
- `npm test` from a detached worktree at commit `d6c8275`

## ✨ Result
`createRepoFileBackedMapSource` is now a compact orchestration function, with the asynchronous file-backed data flow captured in named helpers and regression-tested cache/clone behavior preserved.