### PR TITLE
🎨 Palette: Add aria-atomic attribute to dynamic text containers

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -30,3 +30,6 @@
 ## 2026-06-08 - Icon-Only Button Characters Accessibility
 **Learning:** Using text characters (like '>', 'v', or '-') as makeshift icons inside buttons without explicit `aria-label` attributes results in screen readers reading the literal characters (e.g., "greater than") to users, causing confusion and poor UX.
 **Action:** When implementing icon-only buttons using text characters as symbols, always provide an explicit `aria-label` attribute to describe the action, use `aria-expanded` when acting as a toggle, and set `aria-hidden="true"` on disabled placeholder buttons that have no action.
+## 2024-06-19 - Ensure complete dynamic region readouts
+**Learning:** Screen readers might miss partial updates to dynamic utility output containers (like search results or map options) if `aria-live="polite"` is used without `aria-atomic="true"`.
+**Action:** When creating or modifying dynamic regions that inject complete sets of content (like lists or grids) via JavaScript, always pair `aria-live="polite"` with `aria-atomic="true"` to ensure the screen reader announces the entire updated content instead of just the changed nodes.

--- a/index.html
+++ b/index.html
@@ -130,7 +130,7 @@
                 <h1 id="map-chooser-title">MAP ATLAS</h1>
                 <p id="map-chooser-subtitle">MAPS OF HIRAETH</p>
             </header>
-            <div id="map-chooser-grid" class="map-chooser-grid" aria-live="polite"></div>
+            <div id="map-chooser-grid" class="map-chooser-grid" aria-live="polite" aria-atomic="true"></div>
         </div>
     </section>
 
@@ -239,7 +239,7 @@
                 </button>
             </div>
 
-            <div id="active-filters-container" class="leaflet-control" aria-live="polite"></div>
+            <div id="active-filters-container" class="leaflet-control" aria-live="polite" aria-atomic="true"></div>
             <button id="mobile-info-help-btn" type="button" aria-label="Open map info and help" aria-pressed="false" aria-expanded="false">
                 <i class="ui-icon" data-lucide="info" aria-hidden="true"></i>
             </button>
@@ -328,7 +328,7 @@
                     </div>
                 </div>
             </div>
-            <div id="search-results-container" class="leaflet-control"></div>
+            <div id="search-results-container" class="leaflet-control" aria-live="polite" aria-atomic="true"></div>
             <div id="poi-filter-container" class="leaflet-control">
                  <h3>Filter by Type:</h3>
                  <div class="filter-item">


### PR DESCRIPTION
💡 What: Added `aria-atomic="true"` to the `search-results-container`, `active-filters-container`, and `map-chooser-grid` containers in `index.html`, which already had or needed `aria-live="polite"`.
🎯 Why: To ensure screen readers announce the entire content of these dynamic utility output containers when they are updated with JavaScript (like injected search results or map options), preventing partial or confusing readouts.
📸 Before/After: N/A - Accessibility improvement only.
♿ Accessibility: Greatly improves screen reader experience by making dynamic text updates fully comprehensible.

---
*PR created automatically by Jules for task [1474414525266379357](https://jules.google.com/task/1474414525266379357) started by @jaxsnjohnson*