### PR TITLE
🎨 Palette: Improve screen reader announcements for dynamic status updates

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -30,3 +30,7 @@
 ## 2026-06-08 - Icon-Only Button Characters Accessibility
 **Learning:** Using text characters (like '>', 'v', or '-') as makeshift icons inside buttons without explicit `aria-label` attributes results in screen readers reading the literal characters (e.g., "greater than") to users, causing confusion and poor UX.
 **Action:** When implementing icon-only buttons using text characters as symbols, always provide an explicit `aria-label` attribute to describe the action, use `aria-expanded` when acting as a toggle, and set `aria-hidden="true"` on disabled placeholder buttons that have no action.
+
+## 2026-06-20 - Dynamic Status Announcements
+**Learning:** Screen readers may fail to announce text that is dynamically injected via JavaScript into utility output containers (like status messages or export outcomes) unless explicitly instructed.
+**Action:** When implementing containers for dynamic status updates, always add `aria-live="polite"` and `aria-atomic="true"` to ensure the content changes are announced to assistive technologies without interrupting the user's current flow.

--- a/map-editor.html
+++ b/map-editor.html
@@ -209,7 +209,7 @@
                     <button id="editor-delete-selection-btn" type="button">Delete Selected</button>
                     <button id="editor-reset-view-btn" type="button">Reset View</button>
                 </div>
-                <p id="editor-selection-status" class="map-editor-status">Loading atlas data...</p>
+                <p id="editor-selection-status" class="map-editor-status" aria-live="polite" aria-atomic="true">Loading atlas data...</p>
             </div>
             <div class="map-editor-toolbar-hint">
                 Click a feature to select it. Drag POI markers to move them, and drag orange vertex handles to reshape regions and lines.
@@ -229,7 +229,7 @@
                 <button id="save-atlas-structure-btn" type="button" disabled>Save Atlas Structure</button>
                 <button id="export-current-map-btn" type="button">Export Current Map JSON</button>
                 <button id="export-atlas-structure-btn" type="button">Export Atlas Structure</button>
-                <span id="editor-export-status" aria-live="polite"></span>
+                <span id="editor-export-status" aria-live="polite" aria-atomic="true"></span>
             </div>
         </main>
 


### PR DESCRIPTION
💡 What: Added `aria-live="polite"` and `aria-atomic="true"` to dynamic status message containers (`#editor-selection-status` and `#editor-export-status`) in the map editor.
🎯 Why: Screen readers may fail to announce text injected via JavaScript in utility output containers unless explicitly instructed.
📸 Before/After: Visuals unchanged; screen reader behavior updated.
♿ Accessibility: Ensures users relying on assistive technologies are notified when editor selection or export statuses change.

---
*PR created automatically by Jules for task [698019257412455522](https://jules.google.com/task/698019257412455522) started by @jaxsnjohnson*