### PR TITLE
⚡ Bolt: Use DocumentFragment for list batch DOM insertions

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -129,3 +129,7 @@
 ## 2024-06-25 - Cache Region Filter Groups
 **Learning:** Automatically generating region filter groups involves iterating through potentially thousands of region entries, sorting, and array manipulation. Re-running this multiple times when the regions data pointer is stable causes performance degradation on render paths.
 **Action:** Use a `WeakMap` to cache the derived filter groups object by using the `regions` array as the key, guaranteeing stable cache hits without memory leaks. Furthermore, tracking unique values initially into a plain object `Object.create(null)` bypasses the `Set` conversion overhead (`Array.from(set).sort()`).
+
+## 2024-05-10 - Mocking DocumentFragment in legacy node:vm tests
+**Learning:** When using `DocumentFragment` to optimize DOM insertions in codebases tested with legacy custom mock DOM objects (e.g., `createMockElement` mimicking browser APIs), simple mocks don't natively "dissolve" fragments upon `appendChild` like real browsers do. If `document.createDocumentFragment` is unmocked, it causes `TypeError`. If it's mocked as a regular node, it stays in the mock DOM tree, breaking assertions that look for direct children.
+**Action:** When introducing `DocumentFragment`, verify the test suite's `document` mock. Ensure `createDocumentFragment` is mocked to return a mock fragment node, and proactively update any `childNodes` test assertions that check elements appended from the fragment to account for the fragment acting as a wrapper node in the simplistic mock implementation.

--- a/js/app.js
+++ b/js/app.js
@@ -3154,6 +3154,7 @@ function renderFilterChips(chips) {
         return;
     }
 
+    const fragment = document.createDocumentFragment();
     chips.forEach(chip => {
         const chipEl = document.createElement('span');
         chipEl.className = 'active-filter-chip';
@@ -3169,8 +3170,9 @@ function renderFilterChips(chips) {
         });
 
         chipEl.appendChild(clearBtn);
-        activeFiltersContainer.appendChild(chipEl);
+        fragment.appendChild(chipEl);
     });
+    activeFiltersContainer.appendChild(fragment);
 
     activeFiltersContainer.style.display = 'flex';
 }
@@ -3777,6 +3779,7 @@ function renderRouteSteps(activeStepId) {
     // ⚡ Bolt: Use O(1) Map lookup instead of O(N) Array.find
     const route = currentRoutesById.get(selectedRouteId);
     if (!route) return;
+    const fragment = document.createDocumentFragment();
     route.steps.forEach(step => {
         const div = document.createElement('div');
         div.className = 'list-item';
@@ -3785,8 +3788,9 @@ function renderRouteSteps(activeStepId) {
         div.addEventListener('click', () => {
             startRoute(route.id, step.id);
         });
-        routeStepList.appendChild(div);
+        fragment.appendChild(div);
     });
+    routeStepList.appendChild(fragment);
 }
 
 function updateRouteUrl(routeId, stepId) {
@@ -3920,6 +3924,7 @@ function renderEncounterTableList(tableId) {
         encounterTableList.appendChild(item);
         return;
     }
+    const fragment = document.createDocumentFragment();
     table.entries.forEach((entry, index) => {
         const item = document.createElement('div');
         item.className = 'list-item';
@@ -3932,8 +3937,9 @@ function renderEncounterTableList(tableId) {
 
         item.appendChild(weightSpan);
         item.appendChild(document.createTextNode(` ${result}`));
-        encounterTableList.appendChild(item);
+        fragment.appendChild(item);
     });
+    encounterTableList.appendChild(fragment);
 }
 
 function initializeGMPillDrag() {

--- a/tests/renderEncounterTableList.test.js
+++ b/tests/renderEncounterTableList.test.js
@@ -56,6 +56,7 @@ const sandbox = {
     Promise: Promise,
     JSON: JSON,
     document: {
+        createDocumentFragment: () => createMockElement('document-fragment'),
         createElement: createMockElement,
         createTextNode: (text) => ({ nodeType: 3, textContent: text }),
         addEventListener: () => {},
@@ -107,7 +108,7 @@ tableEntries.length = 0;
 tableEntries.push({ weight: 2, result: 'Goblin' });
 sandbox.renderEncounterTableList('test-table');
 assert.strictEqual(appendedNodes.length, 1);
-const goblinNode = appendedNodes[0];
+const goblinNode = appendedNodes[0].childNodes[0];
 assert.strictEqual(goblinNode.className, 'list-item');
 assert.strictEqual(goblinNode.childNodes[0].textContent, 'x2');
 assert.strictEqual(goblinNode.childNodes[0].className, 'encounter-weight');
@@ -119,7 +120,7 @@ tableEntries.length = 0;
 tableEntries.push({ weight: '<img src=x onerror=alert(1)>', result: '<script>alert("xss")</script>' });
 sandbox.renderEncounterTableList('test-table');
 assert.strictEqual(appendedNodes.length, 1);
-const maliciousNode = appendedNodes[0];
+const maliciousNode = appendedNodes[0].childNodes[0];
 assert.strictEqual(maliciousNode.childNodes[0].textContent, 'x<img src=x onerror=alert(1)>');
 assert.strictEqual(maliciousNode.childNodes[1].textContent, ' <script>alert("xss")</script>');
 assert.strictEqual(maliciousNode.innerHTML, '', 'Should not use innerHTML');


### PR DESCRIPTION
💡 What: Batched DOM insertions using `DocumentFragment` in `renderFilterChips`, `renderRouteSteps`, and `renderEncounterTableList`.
🎯 Why: Modifying the connected live DOM inside a loop causes multiple costly reflows and layout thrashing, hurting UI responsiveness for lists. 
📊 Impact: Reduces layout recalculations and repaints to a single operation per list update.
🔬 Measurement: Inspect performance tracing and UI responsiveness when rendering filters, routes, or encounter tables.

---
*PR created automatically by Jules for task [3455189562695921510](https://jules.google.com/task/3455189562695921510) started by @jaxsnjohnson*