### PR TITLE
🎨 Palette: Add tactile active states to primary UI buttons

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -1799,6 +1799,10 @@ body.embedded-view #share-relay-coachmark {
     transform: scale(1.05); /* Subtle scale effect */
     box-shadow: 0 4px 8px var(--shadow-color);
 }
+.map-control-button:active {
+    transform: scale(0.95);
+    box-shadow: 0 2px 4px var(--shadow-color);
+}
 
 /* --- Zoom Buttons (Custom) --- */
 #custom-zoom-in, #custom-zoom-out, #help-btn {
@@ -3632,6 +3636,9 @@ html.mobile-layout-v2.map-interacting #map-blurb {
     background: color-mix(in srgb, var(--highlight-bg) 82%, var(--bg-primary) 18%);
     border-color: color-mix(in srgb, var(--text-secondary) 28%, var(--glass-border) 72%);
     color: var(--text-primary);
+}
+.sidebar-back-btn:active {
+    transform: scale(0.96);
 }
 
 .sidebar-back-btn .ui-icon {


### PR DESCRIPTION
💡 What: Added tactile `:active` scale-down transformations to `.map-control-button` and `.sidebar-back-btn`.
🎯 Why: The buttons had hover states but lacked physical feedback when clicked, making them feel less responsive. This micro-interaction makes the UI feel more tactile and pleasant to use.
📸 Before/After: N/A (Interaction change)
♿ Accessibility: N/A (Visual polish)

---
*PR created automatically by Jules for task [2199978047176074508](https://jules.google.com/task/2199978047176074508) started by @jaxsnjohnson*