### PR TITLE
🎨 Palette: Add aria-live and aria-atomic to dynamic utility outputs

### DIFF
--- a/index.html
+++ b/index.html
@@ -148,7 +148,7 @@
                 <ul id="map-list">
                 </ul>
             </section>
-            <section id="sidebar-poi-panel" class="sidebar-poi-panel" role="tabpanel" aria-labelledby="sidebar-tab-details" aria-live="polite" hidden></section>
+            <section id="sidebar-poi-panel" class="sidebar-poi-panel" role="tabpanel" aria-labelledby="sidebar-tab-details" aria-live="polite" aria-atomic="true" hidden></section>
             <div class="theme-switch-wrapper">
                 <label class="theme-switch" for="theme-checkbox">
                     <input type="checkbox" id="theme-checkbox" aria-label="Switch to dark theme" title="Switch to dark theme" />
@@ -176,7 +176,7 @@
 
             <div id="loading-indicator" class="initial-loader">
                 <div class="spinner"></div>
-                <div class="loading-text">Loading Map Data...</div>
+                <div class="loading-text" aria-live="polite" aria-atomic="true">Loading Map Data...</div>
                 <div class="progress-container">
                     <div class="progress-bar"></div>
                 </div>
@@ -214,14 +214,14 @@
                     <i class="ui-icon" data-lucide="circle-help" aria-hidden="true"></i>
                 </button>
             </div>
-            <div id="onboarding-coachmark" role="status" aria-live="polite" hidden>
+            <div id="onboarding-coachmark" role="status" aria-live="polite" aria-atomic="true" hidden>
                 <p>New here? Open the Traveler's Guide for controls and shortcuts.</p>
                 <div class="onboarding-actions">
                     <button id="onboarding-open-help-btn" type="button">Open Guide</button>
                     <button id="onboarding-dismiss-btn" type="button">Dismiss</button>
                 </div>
             </div>
-            <div id="share-relay-coachmark" role="status" aria-live="polite" hidden>
+            <div id="share-relay-coachmark" role="status" aria-live="polite" aria-atomic="true" hidden>
                 <p id="share-relay-copy">Shared with you. Pass it on to your party.</p>
                 <div class="onboarding-actions">
                     <button id="share-relay-action-btn" type="button">Share This</button>
@@ -272,7 +272,7 @@
                 </div>
                 <div id="mobile-search-card-body">
                     <div id="mobile-search-card-search-slot"></div>
-                    <div id="mobile-search-card-results-slot" hidden></div>
+                    <div id="mobile-search-card-results-slot" aria-live="polite" aria-atomic="true" hidden></div>
                 </div>
             </div>
             <div id="mobile-tools-card" aria-hidden="true">


### PR DESCRIPTION
💡 What: Added `aria-live="polite"` and `aria-atomic="true"` to dynamic utility outputs such as loading text, POI panel, coachmarks, and search results slot in `index.html`.
🎯 Why: Screen readers may miss partial updates or fail to announce dynamically injected text in utility outputs unless both `aria-live="polite"` and `aria-atomic="true"` are provided.
📸 Before/After: N/A
♿ Accessibility: Ensures that dynamic textual changes are reliably announced by screen readers.

---
*PR created automatically by Jules for task [9294489488067549988](https://jules.google.com/task/9294489488067549988) started by @jaxsnjohnson*