### PR TITLE
⚡ Optimize primary search match indexing

### DIFF
--- a/dist/js/app.js
+++ b/dist/js/app.js
@@ -3113,11 +3113,11 @@ function checkPrimarySearchMatch(term, normalizedPrimary) {
     if (normalizedPrimary === term) {
         return { matched: true, score: 520, matchedByContent: false };
     }
-    if (normalizedPrimary.startsWith(term)) {
+    const primaryIndex = normalizedPrimary.indexOf(term);
+    if (primaryIndex === 0) {
         return { matched: true, score: 430, matchedByContent: false };
     }
-    const primaryIndex = normalizedPrimary.indexOf(term);
-    if (primaryIndex >= 0) {
+    if (primaryIndex > 0) {
         return { matched: true, score: 320 - Math.min(primaryIndex, 120), matchedByContent: false };
     }
 

--- a/js/app.js
+++ b/js/app.js
@@ -3113,11 +3113,11 @@ function checkPrimarySearchMatch(term, normalizedPrimary) {
     if (normalizedPrimary === term) {
         return { matched: true, score: 520, matchedByContent: false };
     }
-    if (normalizedPrimary.startsWith(term)) {
+    const primaryIndex = normalizedPrimary.indexOf(term);
+    if (primaryIndex === 0) {
         return { matched: true, score: 430, matchedByContent: false };
     }
-    const primaryIndex = normalizedPrimary.indexOf(term);
-    if (primaryIndex >= 0) {
+    if (primaryIndex > 0) {
         return { matched: true, score: 320 - Math.min(primaryIndex, 120), matchedByContent: false };
     }
 

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
     "generate:atlas": "node scripts/generate_atlas_index.js",
     "generate:tiles": "node scripts/generate_tiles.js",
     "validate:data": "node scripts/validate_map_data.js",
+    "benchmark:search": "node scripts/benchmark_search_match.js",
     "test:unit": "node --test tests/*.test.js",
     "test:editor-local-access": "node tests/map-editor-local-access.test.js",
     "test:editor-server": "node tests/editor-server.test.js",

--- a/scripts/benchmark_search_match.js
+++ b/scripts/benchmark_search_match.js
@@ -1,0 +1,149 @@
+const fs = require('node:fs');
+const { performance } = require('node:perf_hooks');
+
+const appSource = fs.readFileSync('js/app.js', 'utf8');
+
+function extractFunctionSource(name) {
+    const start = appSource.indexOf(`function ${name}(`);
+    if (start === -1) {
+        throw new Error(`Could not find function ${name}`);
+    }
+
+    let depth = 0;
+    for (let i = start; i < appSource.length; i += 1) {
+        const char = appSource[i];
+        if (char === '{') depth += 1;
+        if (char === '}') {
+            depth -= 1;
+            if (depth === 0) {
+                return appSource.slice(start, i + 1);
+            }
+        }
+    }
+
+    throw new Error(`Could not parse function ${name}`);
+}
+
+const snippets = [
+    extractFunctionSource('getFuzzyMatchScore'),
+    extractFunctionSource('checkPrimarySearchMatch')
+].join('\n');
+
+// eslint-disable-next-line no-eval
+eval(snippets);
+
+function legacyCheckPrimarySearchMatch(term, normalizedPrimary) {
+    if (normalizedPrimary === term) {
+        return { matched: true, score: 520, matchedByContent: false };
+    }
+    if (normalizedPrimary.startsWith(term)) {
+        return { matched: true, score: 430, matchedByContent: false };
+    }
+    const primaryIndex = normalizedPrimary.indexOf(term);
+    if (primaryIndex >= 0) {
+        return { matched: true, score: 320 - Math.min(primaryIndex, 120), matchedByContent: false };
+    }
+
+    const fuzzyScore = getFuzzyMatchScore(term, normalizedPrimary);
+    if (fuzzyScore >= 0) {
+        return { matched: true, score: fuzzyScore, matchedByContent: false };
+    }
+    return null;
+}
+
+function buildCorpus() {
+    const corpus = [];
+    const terms = ['harbor', 'gate', 'market', 'route', 'spire', 'temple', 'watch', 'river'];
+    for (let i = 0; i < 600; i += 1) {
+        for (const term of terms) {
+            const lastChar = term[term.length - 1];
+            corpus.push([term, term]);
+            corpus.push([term, `${term} district ${i}`]);
+            corpus.push([term, `lower ${term} district ${i}`]);
+            corpus.push([term, `${'x'.repeat(145)} ${term} ${i}`]);
+            corpus.push([term, `${term[0]}-${term.slice(1, -1)}-${lastChar} waypoint ${i}`]);
+            corpus.push([term, `unrelated waypoint ${i}`]);
+        }
+    }
+    return corpus;
+}
+
+function runBenchmark(label, matcher, corpus, iterations) {
+    const start = performance.now();
+    let checksum = 0;
+
+    for (let iteration = 0; iteration < iterations; iteration += 1) {
+        for (const [term, normalizedPrimary] of corpus) {
+            const match = matcher(term, normalizedPrimary);
+            if (match) {
+                checksum += match.score;
+                if (match.matchedByContent) checksum += 1;
+            }
+        }
+    }
+
+    return {
+        label,
+        durationMs: performance.now() - start,
+        checksum
+    };
+}
+
+function median(values) {
+    const sorted = [...values].sort((a, b) => a - b);
+    const middle = Math.floor(sorted.length / 2);
+    return sorted.length % 2 === 0
+        ? (sorted[middle - 1] + sorted[middle]) / 2
+        : sorted[middle];
+}
+
+const corpus = buildCorpus();
+const iterations = Number.parseInt(process.env.SEARCH_BENCH_ITERATIONS || '80', 10);
+const rounds = Number.parseInt(process.env.SEARCH_BENCH_ROUNDS || '9', 10);
+const legacyDurations = [];
+const currentDurations = [];
+let legacyChecksum = 0;
+let currentChecksum = 0;
+
+runBenchmark('warmup legacy', legacyCheckPrimarySearchMatch, corpus, 5);
+runBenchmark('warmup current', checkPrimarySearchMatch, corpus, 5);
+
+for (let round = 0; round < rounds; round += 1) {
+    const first = round % 2 === 0
+        ? [
+            ['legacy', legacyCheckPrimarySearchMatch],
+            ['current', checkPrimarySearchMatch]
+        ]
+        : [
+            ['current', checkPrimarySearchMatch],
+            ['legacy', legacyCheckPrimarySearchMatch]
+        ];
+
+    for (const [label, matcher] of first) {
+        const result = runBenchmark(label, matcher, corpus, iterations);
+        if (label === 'legacy') {
+            legacyDurations.push(result.durationMs);
+            legacyChecksum = result.checksum;
+        } else {
+            currentDurations.push(result.durationMs);
+            currentChecksum = result.checksum;
+        }
+    }
+}
+
+if (legacyChecksum !== currentChecksum) {
+    throw new Error(`Benchmark checksums diverged: legacy=${legacyChecksum}, current=${currentChecksum}`);
+}
+
+const legacyMedian = median(legacyDurations);
+const currentMedian = median(currentDurations);
+const delta = legacyMedian - currentMedian;
+const percent = legacyMedian === 0 ? 0 : (delta / legacyMedian) * 100;
+
+console.log(`Corpus entries: ${corpus.length}`);
+console.log(`Iterations per round: ${iterations}`);
+console.log(`Rounds: ${rounds}`);
+console.log(`Legacy median: ${legacyMedian.toFixed(2)} ms`);
+console.log(`Current median: ${currentMedian.toFixed(2)} ms`);
+console.log(`Delta: ${delta.toFixed(2)} ms (${percent.toFixed(2)}%)`);
+console.log(`Checksum: ${currentChecksum}`);


### PR DESCRIPTION
## 💡 What

Optimizes `checkPrimarySearchMatch` so prefix and substring matching share one `indexOf(term)` call. Exact-match scoring is still handled first, prefix matches still score `430`, substring matches still use the same capped positional score, and the Pages bundle copy in `dist/js/app.js` is synced.

Adds `npm run benchmark:search`, a focused benchmark that extracts the app helper, compares it against the previous implementation, and validates matching checksums.

## 🎯 Why

Search matching runs across many normalized map, POI, region, route, and atlas entries. The previous path checked `startsWith(term)` and then, for non-prefix candidates, performed `indexOf(term)`. Reusing one `indexOf` result removes that duplicate primary-string scan on the hot substring path.

## 📊 Measured Improvement

This is a modest measured improvement, not a dramatic speedup.

Baseline before the helper change with `npm run benchmark:search`:

- Corpus entries: `28800`
- Iterations per round: `80`
- Rounds: `9`
- Current median: `417.19 ms`

After the helper change with `npm run benchmark:search`:

- Corpus entries: `28800`
- Iterations per round: `80`
- Rounds: `9`
- Legacy median: `418.93 ms`
- Current median: `415.33 ms`
- Delta: `3.60 ms` (`0.86%` faster)
- Checksum: `622848000`

Heavier confirmation run with `SEARCH_BENCH_ITERATIONS=200 SEARCH_BENCH_ROUNDS=11 npm run benchmark:search`:

- Legacy median: `1029.61 ms`
- Current median: `1024.43 ms`
- Delta: `5.18 ms` (`0.50%` faster)
- Checksum: `1557120000`

## Verification

- `node tests/checkPrimarySearchMatch.test.js`
- `node tests/computeSearchMatch.test.js`
- `npm run test:unit` (`195` tests passed)
- `npm test` (`generate:atlas`, `validate:data`, `test:unit`, `build:pages` passed)

No format or lint scripts are configured in `package.json`.