### PR TITLE
🧪 Test openMobileToolsPanel mobile surface state

### DIFF
--- a/tests/mobile-surface-state.test.js
+++ b/tests/mobile-surface-state.test.js
@@ -40,6 +40,7 @@ global.searchResultsContainer = {
 global.poiSearchInput = { focusCalled: 0, focus() { this.focusCalled += 1; } };
 global.mobileSheetLauncherBtn = { focusCalled: 0, focus() { this.focusCalled += 1; } };
 global.mobileSearchLauncherBtn = { focusCalled: 0, focus() { this.focusCalled += 1; } };
+global.mobileToolsLauncherBtn = { focusCalled: 0, focus() { this.focusCalled += 1; } };
 global.mobileSearchPanel = {
     attrs: {},
     dataset: {},
@@ -178,12 +179,22 @@ assert.equal(global.mobileSurfaceMode, null);
 assert.equal(global.mobileSearchLauncherBtn.focusCalled, 1);
 assert.equal(global.mobileSearchPanel.attrs['aria-hidden'], 'true');
 
-openMobileSheet({ mode: 'tools', triggerButton: global.mobileSearchLauncherBtn });
+openMobileToolsPanel({
+    panelMode: global.MOBILE_TOOLS_PANEL_ROUTES,
+    triggerButton: global.mobileToolsLauncherBtn
+});
 assert.equal(global.mobileSurfaceMode, 'tools');
+assert.equal(global.mobileToolsPanelMode, 'routes');
 assert.equal(global.mobileSearchPanel.attrs['aria-hidden'], 'true');
 assert.equal(global.mobileToolsCard.attrs['aria-hidden'], 'false');
 assert.equal(global.container.classes.has('mobile-tools-card-open'), true);
 assert.equal(global.container.classes.has('mobile-surface-tools'), true);
+
+closeMobileSheet({ restoreFocus: true });
+assert.equal(global.mobileSurfaceMode, null);
+assert.equal(global.mobileToolsPanelMode, null);
+assert.equal(global.mobileToolsLauncherBtn.focusCalled, 1);
+assert.equal(global.mobileToolsCard.attrs['aria-hidden'], 'true');
 
 openMobileSearchPanel({ focusSearch: false, triggerButton: global.mobileSearchLauncherBtn });
 setMapBlurbVisible(true);


### PR DESCRIPTION
## 🎯 What
Adds regression coverage for `openMobileToolsPanel` in `tests/mobile-surface-state.test.js`, using the existing mobile surface state harness around `js/app.js`.

## 📊 Coverage
- Calls `openMobileToolsPanel` directly with the routes panel mode and a tools launcher trigger.
- Verifies the tools surface opens, the tools panel mode is stored, the search panel stays hidden, and the tools card/surface classes are active.
- Closes the sheet and verifies tools panel state resets and focus returns to the tools launcher.

## ✨ Result
This closes the wrapper coverage gap so a regression that opens the wrong mobile surface, drops the requested panel mode, or loses trigger focus restoration is caught by unit tests.

## Validation
- `node --test tests/mobile-surface-state.test.js`
- In-memory mutation check: changing the wrapper to open the search surface failed as expected
- `npm test`