### PR TITLE
🧪 Test closeMobileSearchPanel behavior

### DIFF
--- a/tests/mobile-surface-state.test.js
+++ b/tests/mobile-surface-state.test.js
@@ -178,6 +178,24 @@ assert.equal(global.mobileSurfaceMode, null);
 assert.equal(global.mobileSearchLauncherBtn.focusCalled, 1);
 assert.equal(global.mobileSearchPanel.attrs['aria-hidden'], 'true');
 
+const searchFocusCountAfterSheetClose = global.mobileSearchLauncherBtn.focusCalled;
+closeMobileSearchPanel({ restoreFocus: true });
+assert.equal(global.mobileSurfaceMode, null);
+assert.equal(global.mobileSearchLauncherBtn.focusCalled, searchFocusCountAfterSheetClose);
+
+openMobileSearchPanel({ focusSearch: false, triggerButton: global.mobileSearchLauncherBtn });
+assert.equal(global.mobileSurfaceMode, 'search');
+closeMobileSearchPanel();
+assert.equal(global.mobileSurfaceMode, null);
+assert.equal(global.mobileSearchPanel.attrs['aria-hidden'], 'true');
+assert.equal(global.container.classes.has('mobile-search-card-open'), false);
+assert.equal(global.mobileSearchLauncherBtn.focusCalled, searchFocusCountAfterSheetClose);
+
+openMobileSearchPanel({ focusSearch: false, triggerButton: global.mobileSearchLauncherBtn });
+closeMobileSearchPanel({ restoreFocus: true });
+assert.equal(global.mobileSurfaceMode, null);
+assert.equal(global.mobileSearchLauncherBtn.focusCalled, searchFocusCountAfterSheetClose + 1);
+
 openMobileSheet({ mode: 'tools', triggerButton: global.mobileSearchLauncherBtn });
 assert.equal(global.mobileSurfaceMode, 'tools');
 assert.equal(global.mobileSearchPanel.attrs['aria-hidden'], 'true');

--- a/tests/mobile-surface-state.test.js
+++ b/tests/mobile-surface-state.test.js
@@ -40,6 +40,7 @@ global.searchResultsContainer = {
 global.poiSearchInput = { focusCalled: 0, focus() { this.focusCalled += 1; } };
 global.mobileSheetLauncherBtn = { focusCalled: 0, focus() { this.focusCalled += 1; } };
 global.mobileSearchLauncherBtn = { focusCalled: 0, focus() { this.focusCalled += 1; } };
+global.mobileToolsLauncherBtn = { focusCalled: 0, focus() { this.focusCalled += 1; } };
 global.mobileSearchPanel = {
     attrs: {},
     dataset: {},
@@ -178,12 +179,22 @@ assert.equal(global.mobileSurfaceMode, null);
 assert.equal(global.mobileSearchLauncherBtn.focusCalled, 1);
 assert.equal(global.mobileSearchPanel.attrs['aria-hidden'], 'true');
 
-openMobileSheet({ mode: 'tools', triggerButton: global.mobileSearchLauncherBtn });
+openMobileToolsPanel({
+    panelMode: global.MOBILE_TOOLS_PANEL_ROUTES,
+    triggerButton: global.mobileToolsLauncherBtn
+});
 assert.equal(global.mobileSurfaceMode, 'tools');
+assert.equal(global.mobileToolsPanelMode, 'routes');
 assert.equal(global.mobileSearchPanel.attrs['aria-hidden'], 'true');
 assert.equal(global.mobileToolsCard.attrs['aria-hidden'], 'false');
 assert.equal(global.container.classes.has('mobile-tools-card-open'), true);
 assert.equal(global.container.classes.has('mobile-surface-tools'), true);
+
+closeMobileSheet({ restoreFocus: true });
+assert.equal(global.mobileSurfaceMode, null);
+assert.equal(global.mobileToolsPanelMode, null);
+assert.equal(global.mobileToolsLauncherBtn.focusCalled, 1);
+assert.equal(global.mobileToolsCard.attrs['aria-hidden'], 'true');
 
 openMobileSearchPanel({ focusSearch: false, triggerButton: global.mobileSearchLauncherBtn });
 setMapBlurbVisible(true);


### PR DESCRIPTION
## 🎯 What

Added focused regression coverage for `closeMobileSearchPanel` in `tests/mobile-surface-state.test.js`.

## 📊 Coverage

The mobile surface state harness now verifies that `closeMobileSearchPanel`:

- no-ops safely when no mobile surface is open, even with `restoreFocus: true`
- closes an open search panel with the default `restoreFocus: false` behavior
- resets search panel DOM state and removes the open container class
- forwards `restoreFocus: true` to return focus to the search trigger

## ✨ Result

The public search-panel close wrapper is now covered separately from the lower-level `closeMobileSheet` tests, making future mobile sheet refactors safer.

## Validation

- `node --test tests/mobile-surface-state.test.js`
- `npm run test:unit`
- `npm test`
- Mutation check: temporarily broke `closeMobileSearchPanel` restore-focus forwarding and confirmed the focused test failed before restoring the source.