### PR TITLE
🧪 Add normalizeMobileLayoutMode tests

### DIFF
--- a/tests/normalizeMobileLayoutMode.test.js
+++ b/tests/normalizeMobileLayoutMode.test.js
@@ -1,0 +1,40 @@
+const { describe, it } = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+
+const appSource = fs.readFileSync('js/app.js', 'utf8');
+
+const normalizeStart = appSource.indexOf('function normalizeMobileLayoutMode(');
+const normalizeEnd = appSource.indexOf('function getMobileLayoutModeFromUrl()', normalizeStart);
+
+assert.notEqual(normalizeStart, -1);
+assert.notEqual(normalizeEnd, -1);
+
+const normalizeSource = appSource.slice(normalizeStart, normalizeEnd);
+
+let normalizeMobileLayoutModeRef;
+
+eval(`
+    const MOBILE_LAYOUT_MODE_V2 = 'v2';
+    const MOBILE_LAYOUT_MODE_LEGACY = 'legacy';
+    ${normalizeSource}
+    normalizeMobileLayoutModeRef = normalizeMobileLayoutMode;
+`);
+
+describe('normalizeMobileLayoutMode', () => {
+    it('returns supported layout modes unchanged', () => {
+        assert.equal(normalizeMobileLayoutModeRef('v2'), 'v2');
+        assert.equal(normalizeMobileLayoutModeRef('legacy'), 'legacy');
+    });
+
+    it('trims and lowercases supported layout modes', () => {
+        assert.equal(normalizeMobileLayoutModeRef(' V2 '), 'v2');
+        assert.equal(normalizeMobileLayoutModeRef('\tLEGACY\n'), 'legacy');
+    });
+
+    it('returns null for unsupported and empty values', () => {
+        for (const value of ['modern', 'v3', '', '   ', null, undefined, 0, false]) {
+            assert.equal(normalizeMobileLayoutModeRef(value), null);
+        }
+    });
+});


### PR DESCRIPTION
🎯 **What:** Adds direct `node:test` coverage for `normalizeMobileLayoutMode` in `js/app.js`, filling the gap where neighboring tests covered URL and storage consumers but not the helper contract itself.

📊 **Coverage:** Verifies supported canonical modes (`v2`, `legacy`), whitespace and case normalization, and `null` returns for unsupported, empty, nullish, and non-string falsey values.

✨ **Result:** The mobile layout mode helper now has a focused regression safety net. A temporary mutation check confirmed the test fails when lowercasing is removed from normalization, then the production code was restored.

Validation:
- `node --test tests/normalizeMobileLayoutMode.test.js` (3 tests, 0 failures)
- Temporary mutation check: removing `.toLowerCase()` caused the focused test to fail as expected
- `npm test` (`generate:atlas`, data validation, 198 unit tests, Pages build)