### PR TITLE
🧪 Add openMobileSearchPanel delegation coverage

### DIFF
--- a/tests/openMobileSearchPanel.test.js
+++ b/tests/openMobileSearchPanel.test.js
@@ -1,0 +1,43 @@
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+
+const appSource = fs.readFileSync('js/app.js', 'utf8');
+
+function extractFunctionRange(startMarker, endMarker) {
+    const start = appSource.indexOf(startMarker);
+    if (start === -1) {
+        throw new Error(`Could not find start marker: ${startMarker}`);
+    }
+    const end = appSource.indexOf(endMarker, start);
+    if (end === -1) {
+        throw new Error(`Could not find end marker: ${endMarker}`);
+    }
+    return appSource.slice(start, end);
+}
+
+global.MOBILE_SURFACE_MODE_SEARCH = 'search';
+global.openMobileSheetCalls = [];
+global.openMobileSheet = (options) => {
+    global.openMobileSheetCalls.push(options);
+};
+
+// eslint-disable-next-line no-eval
+eval(extractFunctionRange('function openMobileSearchPanel(', 'function closeMobileSearchPanel('));
+
+const triggerButton = { id: 'mobile-search-launcher-btn' };
+
+openMobileSearchPanel({ focusSearch: true, triggerButton });
+assert.deepEqual(global.openMobileSheetCalls.pop(), {
+    mode: 'search',
+    focusSearch: true,
+    triggerButton
+});
+
+openMobileSearchPanel();
+assert.deepEqual(global.openMobileSheetCalls.pop(), {
+    mode: 'search',
+    focusSearch: false,
+    triggerButton: null
+});
+
+console.log('openMobileSearchPanel delegation checks passed');


### PR DESCRIPTION
## 🎯 What

Adds a focused regression test for `openMobileSearchPanel` in `js/app.js`, covering the wrapper contract around opening the mobile search surface.

## 📊 Coverage

The new test verifies that `openMobileSearchPanel`:

- delegates to `openMobileSheet` with `mode: 'search'`
- preserves a caller-provided `focusSearch: true` flag
- preserves the caller-provided trigger button reference
- uses default `focusSearch: false` and `triggerButton: null` values when called with no options

## ✨ Result

This catches regressions where the mobile search launcher silently opens the wrong surface or drops focus/trigger metadata needed for search focus and focus restoration.

## Validation

- `node tests/openMobileSearchPanel.test.js`
- Intentional break check: changed the wrapper to force `focusSearch: false`; the new test failed on the missing `focusSearch: true` delegation, then the source was restored
- `npm run test:unit` passed with 196 tests
- `npm test` passed from a detached validation worktree, including atlas generation, data validation, unit tests, and Pages bundle build