### PR TITLE
🧪 Add isMobileSurfaceMode coverage

### DIFF
--- a/tests/isMobileSurfaceMode.test.js
+++ b/tests/isMobileSurfaceMode.test.js
@@ -1,0 +1,43 @@
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+
+const appSource = fs.readFileSync('js/app.js', 'utf8');
+
+function extractFunctionSource(name, endSignature) {
+    const start = appSource.indexOf(`function ${name}(`);
+    if (start === -1) {
+        throw new Error(`Could not find function ${name}`);
+    }
+    const end = appSource.indexOf(endSignature, start);
+    if (end === -1) {
+        throw new Error(`Could not parse function ${name}`);
+    }
+    return appSource.slice(start, end);
+}
+
+const snippet = extractFunctionSource('isMobileSurfaceMode', 'function openMobileSheet(');
+
+global.mobileSurfaceMode = null;
+
+// eslint-disable-next-line no-eval
+eval(snippet);
+
+global.mobileSurfaceMode = 'atlas';
+assert.equal(isMobileSurfaceMode('atlas'), true);
+assert.equal(isMobileSurfaceMode('search'), false);
+
+global.mobileSurfaceMode = 'search';
+assert.equal(isMobileSurfaceMode('search'), true);
+assert.equal(isMobileSurfaceMode('tools'), false);
+assert.equal(isMobileSurfaceMode(''), false);
+assert.equal(isMobileSurfaceMode(undefined), false);
+
+global.mobileSurfaceMode = 'tools';
+assert.equal(isMobileSurfaceMode('tools'), true);
+assert.equal(isMobileSurfaceMode('atlas'), false);
+
+global.mobileSurfaceMode = null;
+assert.equal(isMobileSurfaceMode(null), true);
+assert.equal(isMobileSurfaceMode('search'), false);
+
+console.log('isMobileSurfaceMode checks passed');


### PR DESCRIPTION
🎯 **What:** Added focused regression coverage for `isMobileSurfaceMode` in `js/app.js`.

📊 **Coverage:** The new test drives `mobileSurfaceMode` through `atlas`, `search`, `tools`, and `null`, then verifies exact-mode matching and rejects mismatched, empty, and undefined mode inputs.

✨ **Result:** The helper now has direct coverage for the mobile surface state predicate, increasing confidence that callers only activate UI branches for the currently selected mobile surface.

Validation:
- `node --test tests/isMobileSurfaceMode.test.js`
- Mutation check: temporarily changed `isMobileSurfaceMode` to return a truthy state; the new test failed as expected.
- `npm run test:unit`
- `npm test`