### PR TITLE
🧪 Add mobile surface mode label coverage

### DIFF
--- a/tests/getMobileSurfaceModeLabel.test.js
+++ b/tests/getMobileSurfaceModeLabel.test.js
@@ -1,0 +1,49 @@
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+
+const appSource = fs.readFileSync('js/app.js', 'utf8');
+
+function extractFunctionSource(name, endSignature) {
+    const start = appSource.indexOf(`function ${name}(`);
+    if (start === -1) {
+        throw new Error(`Could not find function ${name}`);
+    }
+    const end = appSource.indexOf(endSignature, start);
+    if (end === -1) {
+        throw new Error(`Could not parse function ${name}`);
+    }
+    return appSource.slice(start, end);
+}
+
+const snippet = extractFunctionSource('getMobileSurfaceModeLabel', 'function isMobileSurfaceMode(');
+
+global.MOBILE_SURFACE_MODE_ATLAS = 'atlas';
+global.MOBILE_SURFACE_MODE_SEARCH = 'search';
+global.MOBILE_SURFACE_MODE_TOOLS = 'tools';
+global.mobileSurfaceMode = null;
+
+// eslint-disable-next-line no-eval
+eval(snippet);
+
+assert.equal(getMobileSurfaceModeLabel('atlas'), 'atlas');
+assert.equal(getMobileSurfaceModeLabel('tools'), 'tools');
+assert.equal(getMobileSurfaceModeLabel('search'), 'search');
+
+assert.equal(getMobileSurfaceModeLabel('unknown'), 'search');
+assert.equal(getMobileSurfaceModeLabel(''), 'search');
+assert.equal(getMobileSurfaceModeLabel(null), 'search');
+
+global.mobileSurfaceMode = 'atlas';
+assert.equal(getMobileSurfaceModeLabel(), 'atlas');
+assert.equal(getMobileSurfaceModeLabel(undefined), 'atlas');
+
+global.mobileSurfaceMode = 'tools';
+assert.equal(getMobileSurfaceModeLabel(), 'tools');
+
+global.mobileSurfaceMode = 'search';
+assert.equal(getMobileSurfaceModeLabel(), 'search');
+
+global.mobileSurfaceMode = 'unexpected';
+assert.equal(getMobileSurfaceModeLabel(), 'search');
+
+console.log('getMobileSurfaceModeLabel checks passed');


### PR DESCRIPTION
## 🎯 What
Adds focused regression coverage for `getMobileSurfaceModeLabel` in `js/app.js`.

## 📊 Coverage
- Verifies explicit mode labels for atlas, tools, and search.
- Verifies invalid, empty, and null inputs fall back to `search`.
- Verifies the default `mobileSurfaceMode` path for atlas, tools, search, and unexpected state.

## ✨ Result
Improves confidence around mobile surface UI state labeling and catches regressions where a mode maps to the wrong label.

## Validation
- `node tests/getMobileSurfaceModeLabel.test.js`
- Mutation check: temporarily changed the atlas label branch and confirmed the new test fails with `'search' !== 'atlas'`.
- `npm run test:unit`
- `NODE_PATH=/Users/jaxsnjohnson/github/map.hiraeth/node_modules npm test` from a disposable detached worktree.