### PR TITLE
🔒 Prevent ImageMagick tile argument injection

### DIFF
--- a/scripts/generate_tiles.js
+++ b/scripts/generate_tiles.js
@@ -8,6 +8,13 @@ const { spawnSync } = require('node:child_process');
 const repoRoot = path.resolve(__dirname, '..');
 const defaultTileSize = 256;
 const defaultQuality = 82;
+const imageMagickCodersByExtension = new Map([
+    ['.gif', 'gif'],
+    ['.jpeg', 'jpeg'],
+    ['.jpg', 'jpeg'],
+    ['.png', 'png'],
+    ['.webp', 'webp']
+]);
 
 function isObject(value) {
     return Boolean(value && typeof value === 'object' && !Array.isArray(value));
@@ -95,8 +102,24 @@ function computeTileLevelPlan(mapDocument, tileSource = normalizeTileSource(mapD
     };
 }
 
-function resolveSafeRepoPath(root, relativePath) {
+function assertSafeImageMagickSourcePath(relativePath) {
+    if (/[\0\r\n]/.test(relativePath)) {
+        throw new Error(`Refusing unsafe ImageMagick source path: ${relativePath}`);
+    }
+    if (/^[A-Za-z][A-Za-z0-9+.-]*:/.test(relativePath) || relativePath.startsWith('@') || relativePath === '-') {
+        throw new Error(`Refusing unsafe ImageMagick source path: ${relativePath}`);
+    }
+    if (/[*?[\]{}]/.test(relativePath)) {
+        throw new Error(`Refusing unsafe ImageMagick source path: ${relativePath}`);
+    }
+    if (!imageMagickCodersByExtension.has(path.extname(relativePath).toLowerCase())) {
+        throw new Error(`Unsupported ImageMagick source image type: ${relativePath}`);
+    }
+}
+
+function resolveSafeRepoPath(root, relativePath, options = {}) {
     const normalized = String(relativePath || '').trim();
+    if (options.forImageMagick) assertSafeImageMagickSourcePath(normalized);
     const resolved = path.resolve(root, normalized);
     if (!resolved.startsWith(`${root}${path.sep}`) && resolved !== root) {
         throw new Error(`Refusing to resolve path outside repository: ${relativePath}`);
@@ -134,7 +157,7 @@ function collectTileJobs(root = repoRoot) {
         if (!plan || !plan.mapId || !plan.imageUrl || jobsById.has(plan.mapId)) return;
         jobsById.set(plan.mapId, {
             ...plan,
-            sourceImagePath: resolveSafeRepoPath(root, plan.imageUrl)
+            sourceImagePath: resolveSafeRepoPath(root, plan.imageUrl, { forImageMagick: true })
         });
     });
 
@@ -173,29 +196,64 @@ function runMagick(args, label, magickBinary) {
     }
 }
 
+function isPathInside(root, candidate) {
+    const resolvedRoot = path.resolve(root);
+    const resolvedCandidate = path.resolve(candidate);
+    return resolvedCandidate === resolvedRoot || resolvedCandidate.startsWith(`${resolvedRoot}${path.sep}`);
+}
+
+function formatMagickImagePath(filePath, label, allowedRoot) {
+    const rawPath = String(filePath || '');
+    const resolvedPath = path.resolve(rawPath);
+    if (!rawPath || !path.isAbsolute(rawPath) || rawPath !== resolvedPath) {
+        throw new Error(`${label}: expected a normalized absolute path.`);
+    }
+    if (/[\0\r\n]/.test(rawPath)) {
+        throw new Error(`${label}: unsafe ImageMagick path.`);
+    }
+    if (!isPathInside(allowedRoot, resolvedPath)) {
+        throw new Error(`${label}: refusing ImageMagick path outside allowed directory.`);
+    }
+
+    const coder = imageMagickCodersByExtension.get(path.extname(resolvedPath).toLowerCase());
+    if (!coder) {
+        throw new Error(`${label}: unsupported ImageMagick image type.`);
+    }
+    return `${coder}:${resolvedPath}`;
+}
+
+function buildTileMagickArgs(job, level, levelTmpDir, options = {}) {
+    const outputPattern = path.join(levelTmpDir, 'tile-%06d.webp');
+    return [
+        '--',
+        formatMagickImagePath(job.sourceImagePath, `${job.mapId} source image`, options.repoRoot || repoRoot),
+        '-auto-orient',
+        '-resize',
+        `${level.scaledWidth}x${level.scaledHeight}!`,
+        '-background',
+        'none',
+        '-gravity',
+        'NorthWest',
+        '-extent',
+        `${level.extentWidth}x${level.extentHeight}`,
+        '-crop',
+        `${job.tileSource.tileSize}x${job.tileSource.tileSize}`,
+        '+repage',
+        '-quality',
+        String(job.tileSource.quality),
+        formatMagickImagePath(outputPattern, `${job.mapId} z${level.z} output pattern`, levelTmpDir)
+    ];
+}
+
 function renderTileLevel(job, level, mapOutputDir, options) {
     const levelTmpDir = fs.mkdtempSync(path.join(os.tmpdir(), `map-hiraeth-tiles-${job.mapId}-${level.z}-`));
-    const outputPattern = path.join(levelTmpDir, 'tile-%06d.webp');
 
     try {
-        runMagick([
-            job.sourceImagePath,
-            '-auto-orient',
-            '-resize',
-            `${level.scaledWidth}x${level.scaledHeight}!`,
-            '-background',
-            'none',
-            '-gravity',
-            'NorthWest',
-            '-extent',
-            `${level.extentWidth}x${level.extentHeight}`,
-            '-crop',
-            `${job.tileSource.tileSize}x${job.tileSource.tileSize}`,
-            '+repage',
-            '-quality',
-            String(job.tileSource.quality),
-            outputPattern
-        ], `${job.mapId} z${level.z}`, options.magickBinary);
+        runMagick(
+            buildTileMagickArgs(job, level, levelTmpDir, { repoRoot: options.repoRoot }),
+            `${job.mapId} z${level.z}`,
+            options.magickBinary
+        );
 
         let sequenceIndex = 0;
         for (let y = 0; y < level.rows; y += 1) {
@@ -250,7 +308,7 @@ function generateTiles(options = {}) {
         const mapOutputDir = resolveSafeOutputPath(outputDir, job.mapId);
         fs.rmSync(mapOutputDir, { recursive: true, force: true });
         fs.mkdirSync(mapOutputDir, { recursive: true });
-        job.levels.forEach((level) => renderTileLevel(job, level, mapOutputDir, { magickBinary }));
+        job.levels.forEach((level) => renderTileLevel(job, level, mapOutputDir, { magickBinary, repoRoot: root }));
         totalTiles += job.totalTiles;
         generatedMaps.push({
             id: job.mapId,
@@ -298,6 +356,7 @@ if (require.main === module) {
 }
 
 module.exports = {
+    buildTileMagickArgs,
     collectTileJobs,
     computeTileLevelPlan,
     generateTiles,

--- a/tests/generate-tiles.test.js
+++ b/tests/generate-tiles.test.js
@@ -1,6 +1,15 @@
 const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
 
-const { computeTileLevelPlan, normalizeTileSource, resolveImageMagickBinary } = require('../scripts/generate_tiles.js');
+const {
+    buildTileMagickArgs,
+    collectTileJobs,
+    computeTileLevelPlan,
+    normalizeTileSource,
+    resolveImageMagickBinary
+} = require('../scripts/generate_tiles.js');
 
 const tileSource = normalizeTileSource({
     type: 'xyz',
@@ -82,5 +91,71 @@ assert.throws(
     }),
     /Could not find an ImageMagick command/
 );
+
+{
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), 'map-hiraeth-tile-args-'));
+    const levelTmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'map-hiraeth-tile-output-'));
+    try {
+        const sourceImagePath = path.join(root, 'maps', '-quality.webp');
+        const args = buildTileMagickArgs(
+            {
+                mapId: 'dash_source',
+                sourceImagePath,
+                tileSource: {
+                    tileSize: 256,
+                    quality: 82
+                }
+            },
+            {
+                z: 3,
+                scaledWidth: 512,
+                scaledHeight: 512,
+                extentWidth: 512,
+                extentHeight: 512
+            },
+            levelTmpDir,
+            { repoRoot: root }
+        );
+
+        assert.equal(args[0], '--');
+        assert.equal(args[1], `webp:${sourceImagePath}`);
+        assert.equal(args.at(-1), `webp:${path.join(levelTmpDir, 'tile-%06d.webp')}`);
+    } finally {
+        fs.rmSync(root, { recursive: true, force: true });
+        fs.rmSync(levelTmpDir, { recursive: true, force: true });
+    }
+}
+
+{
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), 'map-hiraeth-unsafe-image-'));
+    try {
+        fs.mkdirSync(path.join(root, 'maps'), { recursive: true });
+        fs.writeFileSync(path.join(root, 'maps', 'atlas-index.json'), `${JSON.stringify({
+            tree: [
+                {
+                    id: 'unsafe_map',
+                    name: 'Unsafe Map',
+                    width: 100,
+                    height: 100,
+                    imageUrl: '@secrets.webp',
+                    tileSource: {
+                        type: 'xyz',
+                        urlTemplate: 'tile/unsafe_map/{z}/{x}/{y}.webp',
+                        tileSize: 256,
+                        minZoom: 0,
+                        maxZoom: 0
+                    }
+                }
+            ]
+        })}\n`);
+
+        assert.throws(
+            () => collectTileJobs(root),
+            /Refusing unsafe ImageMagick source path/
+        );
+    } finally {
+        fs.rmSync(root, { recursive: true, force: true });
+    }
+}
 
 console.log('generate_tiles helper checks passed');


### PR DESCRIPTION
## 🎯 What
Fixes the ImageMagick argument/pseudo-filename injection risk in `scripts/generate_tiles.js`. Tile source paths come from atlas/map JSON and were passed into `spawnSync` as argv entries; that avoids shell metacharacter injection, but ImageMagick still gives filename operands command-specific meaning.

## ⚠️ Risk
A malicious or compromised map config could make tile generation use unexpected ImageMagick filename semantics, including indirect reads, coder/delegate selection, glob/frame syntax, or option-like operands. The blast radius is the local/CI Pages build host and generated tile bundle, not the browser runtime.

## 🛡️ Solution
- Validate ImageMagick source image paths before resolution.
- Reject control characters, coder/URL prefixes, `@` indirect reads, stdin-style `-`, glob/frame metacharacters, and unsupported image types.
- Format ImageMagick source/output operands with explicit web-safe coder prefixes such as `webp:` and enforce absolute paths under the repo or temp tile directory.
- Keep `--` before the input operand where the local ImageMagick CLI accepts it.
- Add regression tests for hyphen-leading source filenames and unsafe `@` source paths.

## Validation
- `git diff --check`
- `node --test tests/generate-tiles.test.js`
- `npm run test:unit` (195 passed)
- `npm test` / `npm run validate:pages` (passed; generated 6309 map tiles and built the Pages bundle with 6423 files)

## Security Context
- ImageMagick command-line docs describe filenames as structured operands with extra semantics beyond plain filesystem paths: https://imagemagick.org/command-line-processing/
- ImageMagick security policy docs recommend constraining paths, coders, indirect reads, resource use, and sandboxing for safer deployments: https://imagemagick.org/security-policy/
- Related historical context: NVD tracks ImageTragick (`CVE-2016-3714`) as improper input validation in ImageMagick coders/delegates: https://nvd.nist.gov/vuln/detail/CVE-2016-3714