### PR TITLE
🧹 Simplify route map step navigation

### DIFF
--- a/dist/js/app.js
+++ b/dist/js/app.js
@@ -4400,6 +4400,19 @@ function updateRouteUrl(routeId, stepId) {
     history.replaceState(history.state, '', url.toString());
 }
 
+function handleRouteMapStepNavigation(route, step) {
+    const targetMapId = step.targetId;
+    if (!targetMapId || targetMapId === currentlyLoadedMapId) return;
+
+    const targetMap = findMapRecursive(mapData, targetMapId);
+    if (!isRenderableMapEntry(targetMap)) {
+        trackAnalytics('route_step_map_unavailable', { routeId: route.id, targetMapId });
+        return;
+    }
+
+    navigateToMap(targetMapId, { preResolvedMap: targetMap, preserveSearch: true });
+}
+
 function focusRouteStep(route, step) {
     if (!route || !step) return;
     renderRouteSteps(step.id);
@@ -4431,14 +4444,7 @@ function focusRouteStep(route, step) {
             break;
         }
         case 'map': {
-            if (step.targetId && step.targetId !== currentlyLoadedMapId) {
-                const targetMap = findMapRecursive(mapData, step.targetId);
-                if (isRenderableMapEntry(targetMap)) {
-                    navigateToMap(step.targetId, { preResolvedMap: targetMap, preserveSearch: true });
-                } else {
-                    trackAnalytics('route_step_map_unavailable', { routeId: route.id, targetMapId: step.targetId });
-                }
-            }
+            handleRouteMapStepNavigation(route, step);
             break;
         }
         default:

--- a/js/app.js
+++ b/js/app.js
@@ -4400,6 +4400,19 @@ function updateRouteUrl(routeId, stepId) {
     history.replaceState(history.state, '', url.toString());
 }
 
+function handleRouteMapStepNavigation(route, step) {
+    const targetMapId = step.targetId;
+    if (!targetMapId || targetMapId === currentlyLoadedMapId) return;
+
+    const targetMap = findMapRecursive(mapData, targetMapId);
+    if (!isRenderableMapEntry(targetMap)) {
+        trackAnalytics('route_step_map_unavailable', { routeId: route.id, targetMapId });
+        return;
+    }
+
+    navigateToMap(targetMapId, { preResolvedMap: targetMap, preserveSearch: true });
+}
+
 function focusRouteStep(route, step) {
     if (!route || !step) return;
     renderRouteSteps(step.id);
@@ -4431,14 +4444,7 @@ function focusRouteStep(route, step) {
             break;
         }
         case 'map': {
-            if (step.targetId && step.targetId !== currentlyLoadedMapId) {
-                const targetMap = findMapRecursive(mapData, step.targetId);
-                if (isRenderableMapEntry(targetMap)) {
-                    navigateToMap(step.targetId, { preResolvedMap: targetMap, preserveSearch: true });
-                } else {
-                    trackAnalytics('route_step_map_unavailable', { routeId: route.id, targetMapId: step.targetId });
-                }
-            }
+            handleRouteMapStepNavigation(route, step);
             break;
         }
         default:

--- a/tests/handleRouteMapStepNavigation.test.js
+++ b/tests/handleRouteMapStepNavigation.test.js
@@ -1,0 +1,86 @@
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+
+const appSource = fs.readFileSync('js/app.js', 'utf8');
+const fnStart = appSource.indexOf('function handleRouteMapStepNavigation(route, step) {');
+const fnEnd = appSource.indexOf('function focusRouteStep(route, step) {');
+
+if (fnStart === -1 || fnEnd === -1 || fnEnd <= fnStart) {
+    throw new Error('Could not locate handleRouteMapStepNavigation in js/app.js');
+}
+
+const fnSource = appSource.slice(fnStart, fnEnd);
+
+let currentlyLoadedMapId = 'current-map';
+let mapData = [
+    { id: 'current-map', url: 'maps/current.json' },
+    { id: 'next-map', url: 'maps/next.json' },
+    { id: 'unrenderable-map' }
+];
+let navigateToMapArgs = null;
+let analyticsEvents = [];
+
+function findMapRecursive(data, id) {
+    return data.find((mapEntry) => mapEntry.id === id) || null;
+}
+
+function isRenderableMapEntry(mapEntry) {
+    return !!(mapEntry && mapEntry.url);
+}
+
+function navigateToMap(...args) {
+    navigateToMapArgs = args;
+}
+
+function trackAnalytics(...args) {
+    analyticsEvents.push(args);
+}
+
+// eslint-disable-next-line no-eval
+eval(fnSource);
+
+function resetState() {
+    currentlyLoadedMapId = 'current-map';
+    navigateToMapArgs = null;
+    analyticsEvents = [];
+}
+
+(function testIgnoresMissingTarget() {
+    resetState();
+    handleRouteMapStepNavigation({ id: 'route-1' }, {});
+
+    assert.equal(navigateToMapArgs, null, 'Missing map target should not navigate');
+    assert.deepEqual(analyticsEvents, [], 'Missing map target should not track unavailable maps');
+})();
+
+(function testIgnoresCurrentMapTarget() {
+    resetState();
+    handleRouteMapStepNavigation({ id: 'route-1' }, { targetId: 'current-map' });
+
+    assert.equal(navigateToMapArgs, null, 'Current map target should not navigate');
+    assert.deepEqual(analyticsEvents, [], 'Current map target should not track unavailable maps');
+})();
+
+(function testNavigatesToRenderableMap() {
+    resetState();
+    const targetMap = mapData[1];
+    handleRouteMapStepNavigation({ id: 'route-1' }, { targetId: 'next-map' });
+
+    assert.deepEqual(navigateToMapArgs, [
+        'next-map',
+        { preResolvedMap: targetMap, preserveSearch: true }
+    ]);
+    assert.deepEqual(analyticsEvents, [], 'Renderable map targets should not be tracked as unavailable');
+})();
+
+(function testTracksUnavailableMap() {
+    resetState();
+    handleRouteMapStepNavigation({ id: 'route-1' }, { targetId: 'unrenderable-map' });
+
+    assert.equal(navigateToMapArgs, null, 'Unavailable map target should not navigate');
+    assert.deepEqual(analyticsEvents, [
+        ['route_step_map_unavailable', { routeId: 'route-1', targetMapId: 'unrenderable-map' }]
+    ]);
+})();
+
+console.log('handleRouteMapStepNavigation tests passed');


### PR DESCRIPTION
## 🎯 What
Extracted the route map-step navigation branch into `handleRouteMapStepNavigation`, replacing the nested conditional in `focusRouteStep` with a single helper call. Synced the shipped Pages runtime in `dist/js/app.js` and added focused coverage in `tests/handleRouteMapStepNavigation.test.js`.

## 💡 Why
The route map-step path had multiple nested checks for target presence, current-map identity, renderability, navigation, and unavailable-map analytics. The helper uses early returns so each branch is explicit and easier to maintain without changing behavior.

## ✅ Verification
- `npm test`
- `npm run test:unit`
- `node --check js/app.js`
- `node --check tests/handleRouteMapStepNavigation.test.js`
- Confirmed `package.json` does not define separate `lint` or `format` scripts.

## ✨ Result
`focusRouteStep` now delegates map-step handling to a small, tested helper while preserving existing navigation and analytics behavior.