### PR TITLE
🧪 Test removeMiniMapControl cleanup

### DIFF
--- a/tests/mobile-minimap-visibility.test.js
+++ b/tests/mobile-minimap-visibility.test.js
@@ -93,6 +93,36 @@ global.miniMapControlMapId = null;
 // eslint-disable-next-line no-eval
 eval(snippets);
 
+assert.doesNotThrow(() => removeMiniMapControl(), 'missing minimap control should be a safe no-op');
+assert.equal(global.miniMapControl, null);
+assert.equal(global.miniMapControlMode, null);
+assert.equal(global.miniMapControlMapId, null);
+
+let directRemoveCalls = 0;
+const directMiniMapControl = {
+    removed: false,
+    remove() {
+        directRemoveCalls += 1;
+        this.removed = true;
+    }
+};
+
+global.miniMapControl = directMiniMapControl;
+global.miniMapControlMode = 'desktop';
+global.miniMapControlMapId = 'default';
+
+removeMiniMapControl();
+
+assert.equal(directRemoveCalls, 1, 'active minimap control should be removed once');
+assert.equal(directMiniMapControl.removed, true, 'active minimap control remove hook should run');
+assert.equal(global.miniMapControl, null, 'minimap control reference should be cleared');
+assert.equal(global.miniMapControlMode, null, 'minimap layout mode should be cleared');
+assert.equal(global.miniMapControlMapId, null, 'minimap map id should be cleared');
+
+removeMiniMapControl();
+
+assert.equal(directRemoveCalls, 1, 'cleanup should be idempotent after the control is removed');
+
 assert.equal(getMiniMapImageUrl({ imageUrl: 'maps/default.webp' }), 'maps/default.mini.webp');
 assert.equal(getMiniMapImageUrl({ imageUrl: 'maps/Old-Lin Map.jpeg' }), 'maps/Old-Lin Map.mini.webp');
 assert.equal(getMiniMapImageUrl({ imageUrl: 'maps/default.webp?asset=1#view' }), 'maps/default.mini.webp?asset=1#view');


### PR DESCRIPTION
🎯 **What:** Adds direct regression coverage for `removeMiniMapControl()` in the existing minimap unit test harness.

📊 **Coverage:** Verifies the cleanup is a safe no-op without an active control, calls the active control's `remove()` hook once, clears `miniMapControl`, `miniMapControlMode`, and `miniMapControlMapId`, and remains idempotent after cleanup.

✨ **Result:** Improves confidence that minimap teardown cannot leave stale control references or mode/map metadata behind during layout, map, or embedded-view transitions.

Validation:
- `node --test tests/mobile-minimap-visibility.test.js`
- Mutation check: temporarily removed `miniMapControlMapId = null`; targeted test failed on the expected stale-map-id assertion.
- `npm run test:unit` (195 tests passed)
- `npm test`