### PR TITLE
⚡ Cache region filter child checkboxes

### DIFF
--- a/dist/js/app.js
+++ b/dist/js/app.js
@@ -4775,6 +4775,7 @@ function populatePOIFilters(pointsOfInterest) {
 }
 
 const filterGroupsCache = new WeakMap();
+const regionGroupNestedCheckboxes = new WeakMap();
 
 function getOrGenerateRegionFilterGroups(regions, selectedMap) {
     // Check if explicit filter groups exist, otherwise auto-generate from data
@@ -4823,6 +4824,38 @@ function getOrGenerateRegionFilterGroups(regions, selectedMap) {
     return regionFilterGroups;
 }
 
+function getRegionGroupNestedCheckboxes(groupCheckbox) {
+    const nestedCheckboxes = regionGroupNestedCheckboxes.get(groupCheckbox);
+    if (nestedCheckboxes) {
+        return nestedCheckboxes;
+    }
+
+    if (!groupCheckbox || typeof groupCheckbox.closest !== 'function') {
+        return [];
+    }
+
+    const groupContainer = groupCheckbox.closest('.filter-group');
+    if (!groupContainer) {
+        return [];
+    }
+
+    const fallbackCheckboxes = Array.from(groupContainer.querySelectorAll('.region-type-filter'));
+    regionGroupNestedCheckboxes.set(groupCheckbox, fallbackCheckboxes);
+    return fallbackCheckboxes;
+}
+
+function setRegionGroupChildCheckboxes(groupCheckbox, checked) {
+    const groupName = groupCheckbox.value;
+    const nestedCheckboxes = getRegionGroupNestedCheckboxes(groupCheckbox);
+
+    for (let i = 0; i < nestedCheckboxes.length; i++) {
+        const checkbox = nestedCheckboxes[i];
+        if (checkbox.dataset.group === groupName) {
+            checkbox.checked = checked;
+        }
+    }
+}
+
 function createRegionFilterGroupDOM(groupName, values) {
     const groupContainer = document.createElement('div');
     groupContainer.className = 'filter-group closed'; // Start as closed
@@ -4857,6 +4890,7 @@ function createRegionFilterGroupDOM(groupName, values) {
 
     const nestedList = document.createElement('div');
     nestedList.className = 'nested-filter-list';
+    const nestedCheckboxes = [];
 
     values.forEach(value => {
         const filterId = `filter-region-value-${value.replace(/\s+/g, '-')}`;
@@ -4869,6 +4903,7 @@ function createRegionFilterGroupDOM(groupName, values) {
         checkbox.checked = true;
         checkbox.className = 'region-type-filter';
         checkbox.dataset.group = groupName;
+        nestedCheckboxes.push(checkbox);
         const label = document.createElement('label');
         label.htmlFor = filterId;
         label.textContent = value;
@@ -4877,6 +4912,7 @@ function createRegionFilterGroupDOM(groupName, values) {
         nestedList.appendChild(div);
     });
     groupContainer.appendChild(nestedList);
+    regionGroupNestedCheckboxes.set(groupCheckbox, nestedCheckboxes);
 
     return groupContainer;
 }
@@ -7267,25 +7303,7 @@ poiFilterContainer.addEventListener('change', (e) => {
 
     // Handle parent group checkbox for regions
     if (target.classList.contains('region-group-filter')) {
-        const isChecked = target.checked;
-        const groupName = target.value;
-
-        // Optimize querying DOM elements since they are created once per group
-        // within populateRegionFilters and not modified dynamically later.
-        // We use a query on target.closest to only find the inputs under that particular group
-        const groupContainer = target.closest('.filter-group');
-        if (groupContainer && !groupContainer._cachedNestedCheckboxes) {
-            // cache onto the groupContainer which is less likely to leak than modifying input properties
-            groupContainer._cachedNestedCheckboxes = groupContainer.querySelectorAll('.region-type-filter');
-        }
-
-        const nestedCheckboxes = groupContainer ? groupContainer._cachedNestedCheckboxes : [];
-        for (let i = 0; i < nestedCheckboxes.length; i++) {
-            const checkbox = nestedCheckboxes[i];
-            if (checkbox.dataset.group === groupName) {
-                checkbox.checked = isChecked;
-            }
-        }
+        setRegionGroupChildCheckboxes(target, target.checked);
     }
 
     // Handle master "Show All / Hide All" checkbox

--- a/js/app.js
+++ b/js/app.js
@@ -4775,6 +4775,7 @@ function populatePOIFilters(pointsOfInterest) {
 }
 
 const filterGroupsCache = new WeakMap();
+const regionGroupNestedCheckboxes = new WeakMap();
 
 function getOrGenerateRegionFilterGroups(regions, selectedMap) {
     // Check if explicit filter groups exist, otherwise auto-generate from data
@@ -4823,6 +4824,38 @@ function getOrGenerateRegionFilterGroups(regions, selectedMap) {
     return regionFilterGroups;
 }
 
+function getRegionGroupNestedCheckboxes(groupCheckbox) {
+    const nestedCheckboxes = regionGroupNestedCheckboxes.get(groupCheckbox);
+    if (nestedCheckboxes) {
+        return nestedCheckboxes;
+    }
+
+    if (!groupCheckbox || typeof groupCheckbox.closest !== 'function') {
+        return [];
+    }
+
+    const groupContainer = groupCheckbox.closest('.filter-group');
+    if (!groupContainer) {
+        return [];
+    }
+
+    const fallbackCheckboxes = Array.from(groupContainer.querySelectorAll('.region-type-filter'));
+    regionGroupNestedCheckboxes.set(groupCheckbox, fallbackCheckboxes);
+    return fallbackCheckboxes;
+}
+
+function setRegionGroupChildCheckboxes(groupCheckbox, checked) {
+    const groupName = groupCheckbox.value;
+    const nestedCheckboxes = getRegionGroupNestedCheckboxes(groupCheckbox);
+
+    for (let i = 0; i < nestedCheckboxes.length; i++) {
+        const checkbox = nestedCheckboxes[i];
+        if (checkbox.dataset.group === groupName) {
+            checkbox.checked = checked;
+        }
+    }
+}
+
 function createRegionFilterGroupDOM(groupName, values) {
     const groupContainer = document.createElement('div');
     groupContainer.className = 'filter-group closed'; // Start as closed
@@ -4857,6 +4890,7 @@ function createRegionFilterGroupDOM(groupName, values) {
 
     const nestedList = document.createElement('div');
     nestedList.className = 'nested-filter-list';
+    const nestedCheckboxes = [];
 
     values.forEach(value => {
         const filterId = `filter-region-value-${value.replace(/\s+/g, '-')}`;
@@ -4869,6 +4903,7 @@ function createRegionFilterGroupDOM(groupName, values) {
         checkbox.checked = true;
         checkbox.className = 'region-type-filter';
         checkbox.dataset.group = groupName;
+        nestedCheckboxes.push(checkbox);
         const label = document.createElement('label');
         label.htmlFor = filterId;
         label.textContent = value;
@@ -4877,6 +4912,7 @@ function createRegionFilterGroupDOM(groupName, values) {
         nestedList.appendChild(div);
     });
     groupContainer.appendChild(nestedList);
+    regionGroupNestedCheckboxes.set(groupCheckbox, nestedCheckboxes);
 
     return groupContainer;
 }
@@ -7267,25 +7303,7 @@ poiFilterContainer.addEventListener('change', (e) => {
 
     // Handle parent group checkbox for regions
     if (target.classList.contains('region-group-filter')) {
-        const isChecked = target.checked;
-        const groupName = target.value;
-
-        // Optimize querying DOM elements since they are created once per group
-        // within populateRegionFilters and not modified dynamically later.
-        // We use a query on target.closest to only find the inputs under that particular group
-        const groupContainer = target.closest('.filter-group');
-        if (groupContainer && !groupContainer._cachedNestedCheckboxes) {
-            // cache onto the groupContainer which is less likely to leak than modifying input properties
-            groupContainer._cachedNestedCheckboxes = groupContainer.querySelectorAll('.region-type-filter');
-        }
-
-        const nestedCheckboxes = groupContainer ? groupContainer._cachedNestedCheckboxes : [];
-        for (let i = 0; i < nestedCheckboxes.length; i++) {
-            const checkbox = nestedCheckboxes[i];
-            if (checkbox.dataset.group === groupName) {
-                checkbox.checked = isChecked;
-            }
-        }
+        setRegionGroupChildCheckboxes(target, target.checked);
     }
 
     // Handle master "Show All / Hide All" checkbox

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
     "generate:tiles": "node scripts/generate_tiles.js",
     "validate:data": "node scripts/validate_map_data.js",
     "benchmark:search": "node scripts/benchmark_search_match.js",
+    "benchmark:region-filters": "node scripts/benchmark_region_filter_groups.js",
     "test:unit": "node --test tests/*.test.js",
     "test:editor-local-access": "node tests/map-editor-local-access.test.js",
     "test:editor-server": "node tests/editor-server.test.js",

--- a/scripts/benchmark_region_filter_groups.js
+++ b/scripts/benchmark_region_filter_groups.js
@@ -1,0 +1,167 @@
+const { performance } = require('node:perf_hooks');
+const { JSDOM } = require('jsdom');
+
+const groupCount = Number.parseInt(process.env.REGION_FILTER_BENCH_GROUPS || '180', 10);
+const childrenPerGroup = Number.parseInt(process.env.REGION_FILTER_BENCH_CHILDREN || '24', 10);
+const rounds = Number.parseInt(process.env.REGION_FILTER_BENCH_ROUNDS || '9', 10);
+
+function buildRegionFilterDOM(mapChildren) {
+    const { document } = (new JSDOM('<!doctype html><div id="filters"></div>')).window;
+    const container = document.getElementById('filters');
+    const childMap = new WeakMap();
+    const groupCheckboxes = [];
+
+    for (let groupIndex = 0; groupIndex < groupCount; groupIndex += 1) {
+        const groupName = `region-group-${groupIndex}`;
+        const groupContainer = document.createElement('div');
+        groupContainer.className = 'filter-group closed';
+
+        const groupHeader = document.createElement('div');
+        groupHeader.className = 'filter-group-header';
+
+        const groupCheckbox = document.createElement('input');
+        groupCheckbox.type = 'checkbox';
+        groupCheckbox.value = groupName;
+        groupCheckbox.checked = true;
+        groupCheckbox.className = 'region-group-filter';
+
+        groupHeader.appendChild(groupCheckbox);
+        groupContainer.appendChild(groupHeader);
+
+        const nestedList = document.createElement('div');
+        nestedList.className = 'nested-filter-list';
+        const nestedCheckboxes = [];
+
+        for (let childIndex = 0; childIndex < childrenPerGroup; childIndex += 1) {
+            const checkbox = document.createElement('input');
+            checkbox.type = 'checkbox';
+            checkbox.value = `region-${groupIndex}-${childIndex}`;
+            checkbox.checked = true;
+            checkbox.className = 'region-type-filter';
+            checkbox.dataset.group = groupName;
+            nestedCheckboxes.push(checkbox);
+            nestedList.appendChild(checkbox);
+        }
+
+        groupContainer.appendChild(nestedList);
+        container.appendChild(groupContainer);
+        groupCheckboxes.push(groupCheckbox);
+
+        if (mapChildren) {
+            childMap.set(groupCheckbox, nestedCheckboxes);
+        }
+    }
+
+    return { childMap, groupCheckboxes };
+}
+
+function runLegacyToggle(groupCheckboxes, checked) {
+    let checksum = 0;
+
+    for (let i = 0; i < groupCheckboxes.length; i += 1) {
+        const target = groupCheckboxes[i];
+        const groupName = target.value;
+        const groupContainer = target.closest('.filter-group');
+        if (groupContainer && !groupContainer._cachedNestedCheckboxes) {
+            groupContainer._cachedNestedCheckboxes = groupContainer.querySelectorAll('.region-type-filter');
+        }
+
+        const nestedCheckboxes = groupContainer ? groupContainer._cachedNestedCheckboxes : [];
+        for (let j = 0; j < nestedCheckboxes.length; j += 1) {
+            const checkbox = nestedCheckboxes[j];
+            if (checkbox.dataset.group === groupName) {
+                checkbox.checked = checked;
+                checksum += checkbox.checked ? 1 : 3;
+            }
+        }
+    }
+
+    return checksum;
+}
+
+function runMappedToggle(groupCheckboxes, childMap, checked) {
+    let checksum = 0;
+
+    for (let i = 0; i < groupCheckboxes.length; i += 1) {
+        const target = groupCheckboxes[i];
+        const groupName = target.value;
+        const nestedCheckboxes = childMap.get(target) || [];
+        for (let j = 0; j < nestedCheckboxes.length; j += 1) {
+            const checkbox = nestedCheckboxes[j];
+            if (checkbox.dataset.group === groupName) {
+                checkbox.checked = checked;
+                checksum += checkbox.checked ? 1 : 3;
+            }
+        }
+    }
+
+    return checksum;
+}
+
+function median(values) {
+    const sorted = [...values].sort((a, b) => a - b);
+    const middle = Math.floor(sorted.length / 2);
+    return sorted.length % 2 === 0
+        ? (sorted[middle - 1] + sorted[middle]) / 2
+        : sorted[middle];
+}
+
+function measureTogglePath(label, buildMapped, runner) {
+    const durations = [];
+    let checksum = 0;
+
+    for (let round = 0; round < rounds; round += 1) {
+        const setup = buildRegionFilterDOM(buildMapped);
+        const start = performance.now();
+        checksum = runner(setup, round % 2 === 0);
+        durations.push(performance.now() - start);
+    }
+
+    return {
+        label,
+        medianMs: median(durations),
+        checksum
+    };
+}
+
+function measurePopulateAndToggle(label, buildMapped, runner) {
+    const durations = [];
+    let checksum = 0;
+
+    for (let round = 0; round < rounds; round += 1) {
+        const start = performance.now();
+        const setup = buildRegionFilterDOM(buildMapped);
+        checksum = runner(setup, round % 2 === 0);
+        durations.push(performance.now() - start);
+    }
+
+    return {
+        label,
+        medianMs: median(durations),
+        checksum
+    };
+}
+
+function printComparison(name, legacy, mapped) {
+    if (legacy.checksum !== mapped.checksum) {
+        throw new Error(`${name} checksums diverged: legacy=${legacy.checksum}, mapped=${mapped.checksum}`);
+    }
+
+    const delta = legacy.medianMs - mapped.medianMs;
+    const percent = legacy.medianMs === 0 ? 0 : (delta / legacy.medianMs) * 100;
+    console.log(`${name}:`);
+    console.log(`  Legacy median: ${legacy.medianMs.toFixed(2)} ms`);
+    console.log(`  Mapped median: ${mapped.medianMs.toFixed(2)} ms`);
+    console.log(`  Delta: ${delta.toFixed(2)} ms (${percent.toFixed(2)}%)`);
+}
+
+const legacyToggle = measureTogglePath('legacy', false, (setup, checked) => runLegacyToggle(setup.groupCheckboxes, checked));
+const mappedToggle = measureTogglePath('mapped', true, (setup, checked) => runMappedToggle(setup.groupCheckboxes, setup.childMap, checked));
+const legacyEndToEnd = measurePopulateAndToggle('legacy', false, (setup, checked) => runLegacyToggle(setup.groupCheckboxes, checked));
+const mappedEndToEnd = measurePopulateAndToggle('mapped', true, (setup, checked) => runMappedToggle(setup.groupCheckboxes, setup.childMap, checked));
+
+console.log(`Groups: ${groupCount}`);
+console.log(`Children per group: ${childrenPerGroup}`);
+console.log(`Rounds: ${rounds}`);
+printComparison('First parent-toggle path', legacyToggle, mappedToggle);
+printComparison('Populate plus first parent-toggle path', legacyEndToEnd, mappedEndToEnd);

--- a/tests/region-filter-group-checkbox-map.test.js
+++ b/tests/region-filter-group-checkbox-map.test.js
@@ -1,0 +1,68 @@
+const { test } = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const { JSDOM } = require('jsdom');
+
+const appSource = fs.readFileSync('js/app.js', 'utf8');
+const helperStart = appSource.indexOf('const regionGroupNestedCheckboxes = new WeakMap();');
+const helperEnd = appSource.indexOf('function populateRegionFilters', helperStart);
+
+if (helperStart === -1 || helperEnd === -1 || helperEnd <= helperStart) {
+    throw new Error('Could not locate region filter group helpers in js/app.js');
+}
+
+const helperSource = appSource.slice(helperStart, helperEnd);
+const exported = {};
+
+// eslint-disable-next-line no-eval
+eval(`${helperSource}
+exported.createRegionFilterGroupDOM = createRegionFilterGroupDOM;
+exported.getRegionGroupNestedCheckboxes = getRegionGroupNestedCheckboxes;
+exported.setRegionGroupChildCheckboxes = setRegionGroupChildCheckboxes;`);
+
+function installDocument() {
+    const { window } = new JSDOM('<!doctype html><div id="root"></div>');
+    global.document = window.document;
+    return window.document;
+}
+
+test('createRegionFilterGroupDOM registers child checkboxes for parent toggles', () => {
+    installDocument();
+
+    const groupContainer = exported.createRegionFilterGroupDOM('Terrain', ['Forest', 'River', 'Mountain']);
+    const groupCheckbox = groupContainer.querySelector('.region-group-filter');
+    const domCheckboxes = Array.from(groupContainer.querySelectorAll('.region-type-filter'));
+    const mappedCheckboxes = exported.getRegionGroupNestedCheckboxes(groupCheckbox);
+
+    assert.equal(mappedCheckboxes.length, 3);
+    assert.deepEqual(mappedCheckboxes, domCheckboxes);
+    assert.deepEqual(mappedCheckboxes.map(checkbox => checkbox.value), ['Forest', 'River', 'Mountain']);
+
+    exported.setRegionGroupChildCheckboxes(groupCheckbox, false);
+    assert.deepEqual(mappedCheckboxes.map(checkbox => checkbox.checked), [false, false, false]);
+
+    exported.setRegionGroupChildCheckboxes(groupCheckbox, true);
+    assert.deepEqual(mappedCheckboxes.map(checkbox => checkbox.checked), [true, true, true]);
+});
+
+test('setRegionGroupChildCheckboxes falls back for compatible unregistered DOM', () => {
+    const document = installDocument();
+    const groupContainer = document.createElement('div');
+    groupContainer.className = 'filter-group';
+    groupContainer.innerHTML = `
+        <input type="checkbox" class="region-group-filter" value="Terrain">
+        <input type="checkbox" class="region-type-filter" data-group="Terrain" checked>
+        <input type="checkbox" class="region-type-filter" data-group="Terrain" checked>
+        <input type="checkbox" class="region-type-filter" data-group="Other" checked>
+    `;
+    document.getElementById('root').appendChild(groupContainer);
+
+    const groupCheckbox = groupContainer.querySelector('.region-group-filter');
+    const terrainCheckboxes = Array.from(groupContainer.querySelectorAll('[data-group="Terrain"]'));
+    const otherCheckbox = groupContainer.querySelector('[data-group="Other"]');
+
+    exported.setRegionGroupChildCheckboxes(groupCheckbox, false);
+
+    assert.deepEqual(terrainCheckboxes.map(checkbox => checkbox.checked), [false, false]);
+    assert.equal(otherCheckbox.checked, true);
+});


### PR DESCRIPTION
💡 **What:**
- Registers each region group checkbox's nested `.region-type-filter` inputs during `createRegionFilterGroupDOM` population.
- Replaces the parent-filter change handler's `closest(...).querySelectorAll(...)` path with a `WeakMap` lookup plus a defensive fallback for compatible unregistered DOM.
- Adds `benchmark:region-filters` and focused regression coverage for mapped parent toggles.

🎯 **Why:**
- Parent region toggles no longer need to discover nested checkboxes with DOM queries after the filter tree has already been built.
- This keeps the hot change-handler path on direct array iteration and avoids coupling cached state to DOM element properties.

📊 **Measured Improvement:**
- Benchmark: `npm run benchmark:region-filters` with 180 groups, 24 children per group, 9 rounds.
- First parent-toggle path: legacy `15.08 ms` median, mapped `4.77 ms` median, `10.30 ms` faster (`68.33%`).
- Populate plus first parent-toggle path: legacy `58.81 ms` median, mapped `49.04 ms` median, `9.77 ms` faster (`16.62%`).

Validation:
- `npm run benchmark:region-filters`
- `node --test tests/region-filter-group-checkbox-map.test.js`
- `npm test`
- `cmp -s js/app.js dist/js/app.js`