### PR TITLE
🧹 Fix too many parameters in attachFolderEventListeners

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -6212,7 +6212,7 @@ function createFolderMainAction(folderName, isLoadable, isComingSoon) {
     return mainAction;
 }
 
-function attachFolderEventListeners(item, folderName, isLoadable, isComingSoon, header, toggleBtn, mainAction, toggleFolderOpen) {
+function attachFolderEventListeners({ item, folderName, isLoadable, isComingSoon, header, toggleBtn, mainAction, toggleFolderOpen }) {
     toggleBtn.addEventListener('click', toggleFolderOpen);
     toggleBtn.addEventListener('keydown', (e) => {
         if (e.key === 'Enter' || e.key === ' ') {
@@ -6292,7 +6292,7 @@ function createSidebarFolderItem(item) {
         syncFolderExpandedAria(listItem);
     };
 
-    attachFolderEventListeners(item, folderName, isLoadable, isComingSoon, header, toggleBtn, mainAction, toggleFolderOpen);
+    attachFolderEventListeners({ item, folderName, isLoadable, isComingSoon, header, toggleBtn, mainAction, toggleFolderOpen });
 
     syncFolderExpandedAria(listItem);
 


### PR DESCRIPTION
🎯 **What:** Refactored `attachFolderEventListeners` to accept a single options object instead of 8 positional parameters.
💡 **Why:** Reduces parameter count and improves maintainability and readability.
✅ **Verification:** Ran `pnpm run test:unit` and full `pnpm run test` to verify no regressions in functionality.
✨ **Result:** A much cleaner function signature.

---
*PR created automatically by Jules for task [1439889965877667498](https://jules.google.com/task/1439889965877667498) started by @jaxsnjohnson*