### PR TITLE
⚡ Cache secondary search match results

### DIFF
--- a/dist/js/app.js
+++ b/dist/js/app.js
@@ -3159,6 +3159,24 @@ function normalizeSearchValue(value) {
     return String(value || '').trim().toLowerCase();
 }
 
+function getSecondarySearchMatchCache(searchContext, normalizedText) {
+    if (!searchContext || !normalizedText) return null;
+    if (searchContext._secondarySearchMatchText !== normalizedText) {
+        searchContext._secondarySearchMatchText = normalizedText;
+        searchContext._secondarySearchMatchCache = new Map();
+    }
+    return searchContext._secondarySearchMatchCache;
+}
+
+function rememberSecondarySearchMatch(searchCache, term, match) {
+    if (!searchCache) return;
+    if (searchCache.size >= 32) {
+        const oldestKey = searchCache.keys().next().value;
+        searchCache.delete(oldestKey);
+    }
+    searchCache.set(term, match);
+}
+
 function getFuzzyMatchScore(term, target) {
     if (!term || !target) return -1;
     let searchIndex = 0;
@@ -3197,14 +3215,28 @@ function checkPrimarySearchMatch(term, normalizedPrimary) {
     return null;
 }
 
-function checkSecondarySearchMatch(term, normalizedSecondary) {
-    if (normalizedSecondary.includes(term)) {
-        return { matched: true, score: 180, matchedByContent: true };
+function checkSecondarySearchMatch(term, normalizedSecondary, searchContext = null) {
+    const searchCache = getSecondarySearchMatchCache(searchContext, normalizedSecondary);
+    if (searchCache && searchCache.has(term)) {
+        return searchCache.get(term);
     }
+
+    if (!term) {
+        const emptyTermMatch = { matched: true, score: 180, matchedByContent: true };
+        rememberSecondarySearchMatch(searchCache, term, emptyTermMatch);
+        return emptyTermMatch;
+    }
+
     const fuzzySecondaryScore = getFuzzyMatchScore(term, normalizedSecondary);
     if (fuzzySecondaryScore >= 0) {
-        return { matched: true, score: Math.max(80, fuzzySecondaryScore - 40), matchedByContent: true };
+        const secondaryMatch = fuzzySecondaryScore === 160 || normalizedSecondary.includes(term)
+            ? { matched: true, score: 180, matchedByContent: true }
+            : { matched: true, score: Math.max(80, fuzzySecondaryScore - 40), matchedByContent: true };
+        rememberSecondarySearchMatch(searchCache, term, secondaryMatch);
+        return secondaryMatch;
     }
+
+    rememberSecondarySearchMatch(searchCache, term, null);
     return null;
 }
 
@@ -4137,14 +4169,14 @@ function sortSearchResults(results) {
         .slice(0, 40);
 }
 
-function computePrecomputedSearchMatch(term, normalizedPrimary, normalizedSecondary) {
+function computePrecomputedSearchMatch(term, normalizedPrimary, normalizedSecondary, secondarySearchContext = null) {
     if (!term || !normalizedPrimary) return { matched: false, score: -1, matchedByContent: false };
 
     const primaryMatch = checkPrimarySearchMatch(term, normalizedPrimary);
     if (primaryMatch) return primaryMatch;
 
     if (normalizedSecondary) {
-        const secondaryMatch = checkSecondarySearchMatch(term, normalizedSecondary);
+        const secondaryMatch = checkSecondarySearchMatch(term, normalizedSecondary, secondarySearchContext);
         if (secondaryMatch) return secondaryMatch;
     }
 
@@ -4180,7 +4212,12 @@ function searchMapMarkers(searchTerm, results, allPoiGroupsChecked, activeSpecif
                 searchContext.normalizedPrimary = normalizeSearchValue(poi.name);
                 searchContext.normalizedSecondary = normalizeSearchValue(getFeatureSearchDetailText(poi));
             }
-            match = computePrecomputedSearchMatch(searchTerm, searchContext.normalizedPrimary, searchContext.normalizedSecondary);
+            match = computePrecomputedSearchMatch(
+                searchTerm,
+                searchContext.normalizedPrimary,
+                searchContext.normalizedSecondary,
+                searchContext
+            );
         }
         const isSearchMatch = !hasSearchTerm || match.matched;
 
@@ -4344,7 +4381,8 @@ function searchAtlasIndex(searchTerm, results) {
             const match = computePrecomputedSearchMatch(
                 searchTerm,
                 entry._normalizedName ?? normalizeSearchValue(entry.name),
-                entry._normalizedSearchContent ?? normalizeSearchValue(`${entry.mapName || ''} ${entry.typeLabel || ''} ${entry.summary || ''} ${entry.description || ''} ${entry.searchText || ''}`)
+                entry._normalizedSearchContent ?? normalizeSearchValue(`${entry.mapName || ''} ${entry.typeLabel || ''} ${entry.summary || ''} ${entry.description || ''} ${entry.searchText || ''}`),
+                entry
             );
 
             if (!match.matched) continue;

--- a/js/app.js
+++ b/js/app.js
@@ -3159,6 +3159,24 @@ function normalizeSearchValue(value) {
     return String(value || '').trim().toLowerCase();
 }
 
+function getSecondarySearchMatchCache(searchContext, normalizedText) {
+    if (!searchContext || !normalizedText) return null;
+    if (searchContext._secondarySearchMatchText !== normalizedText) {
+        searchContext._secondarySearchMatchText = normalizedText;
+        searchContext._secondarySearchMatchCache = new Map();
+    }
+    return searchContext._secondarySearchMatchCache;
+}
+
+function rememberSecondarySearchMatch(searchCache, term, match) {
+    if (!searchCache) return;
+    if (searchCache.size >= 32) {
+        const oldestKey = searchCache.keys().next().value;
+        searchCache.delete(oldestKey);
+    }
+    searchCache.set(term, match);
+}
+
 function getFuzzyMatchScore(term, target) {
     if (!term || !target) return -1;
     let searchIndex = 0;
@@ -3197,14 +3215,28 @@ function checkPrimarySearchMatch(term, normalizedPrimary) {
     return null;
 }
 
-function checkSecondarySearchMatch(term, normalizedSecondary) {
-    if (normalizedSecondary.includes(term)) {
-        return { matched: true, score: 180, matchedByContent: true };
+function checkSecondarySearchMatch(term, normalizedSecondary, searchContext = null) {
+    const searchCache = getSecondarySearchMatchCache(searchContext, normalizedSecondary);
+    if (searchCache && searchCache.has(term)) {
+        return searchCache.get(term);
     }
+
+    if (!term) {
+        const emptyTermMatch = { matched: true, score: 180, matchedByContent: true };
+        rememberSecondarySearchMatch(searchCache, term, emptyTermMatch);
+        return emptyTermMatch;
+    }
+
     const fuzzySecondaryScore = getFuzzyMatchScore(term, normalizedSecondary);
     if (fuzzySecondaryScore >= 0) {
-        return { matched: true, score: Math.max(80, fuzzySecondaryScore - 40), matchedByContent: true };
+        const secondaryMatch = fuzzySecondaryScore === 160 || normalizedSecondary.includes(term)
+            ? { matched: true, score: 180, matchedByContent: true }
+            : { matched: true, score: Math.max(80, fuzzySecondaryScore - 40), matchedByContent: true };
+        rememberSecondarySearchMatch(searchCache, term, secondaryMatch);
+        return secondaryMatch;
     }
+
+    rememberSecondarySearchMatch(searchCache, term, null);
     return null;
 }
 
@@ -4137,14 +4169,14 @@ function sortSearchResults(results) {
         .slice(0, 40);
 }
 
-function computePrecomputedSearchMatch(term, normalizedPrimary, normalizedSecondary) {
+function computePrecomputedSearchMatch(term, normalizedPrimary, normalizedSecondary, secondarySearchContext = null) {
     if (!term || !normalizedPrimary) return { matched: false, score: -1, matchedByContent: false };
 
     const primaryMatch = checkPrimarySearchMatch(term, normalizedPrimary);
     if (primaryMatch) return primaryMatch;
 
     if (normalizedSecondary) {
-        const secondaryMatch = checkSecondarySearchMatch(term, normalizedSecondary);
+        const secondaryMatch = checkSecondarySearchMatch(term, normalizedSecondary, secondarySearchContext);
         if (secondaryMatch) return secondaryMatch;
     }
 
@@ -4180,7 +4212,12 @@ function searchMapMarkers(searchTerm, results, allPoiGroupsChecked, activeSpecif
                 searchContext.normalizedPrimary = normalizeSearchValue(poi.name);
                 searchContext.normalizedSecondary = normalizeSearchValue(getFeatureSearchDetailText(poi));
             }
-            match = computePrecomputedSearchMatch(searchTerm, searchContext.normalizedPrimary, searchContext.normalizedSecondary);
+            match = computePrecomputedSearchMatch(
+                searchTerm,
+                searchContext.normalizedPrimary,
+                searchContext.normalizedSecondary,
+                searchContext
+            );
         }
         const isSearchMatch = !hasSearchTerm || match.matched;
 
@@ -4344,7 +4381,8 @@ function searchAtlasIndex(searchTerm, results) {
             const match = computePrecomputedSearchMatch(
                 searchTerm,
                 entry._normalizedName ?? normalizeSearchValue(entry.name),
-                entry._normalizedSearchContent ?? normalizeSearchValue(`${entry.mapName || ''} ${entry.typeLabel || ''} ${entry.summary || ''} ${entry.description || ''} ${entry.searchText || ''}`)
+                entry._normalizedSearchContent ?? normalizeSearchValue(`${entry.mapName || ''} ${entry.typeLabel || ''} ${entry.summary || ''} ${entry.description || ''} ${entry.searchText || ''}`),
+                entry
             );
 
             if (!match.matched) continue;

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
     "generate:tiles": "node scripts/generate_tiles.js",
     "validate:data": "node scripts/validate_map_data.js",
     "benchmark:search": "node scripts/benchmark_search_match.js",
+    "benchmark:secondary-search": "node scripts/benchmark_secondary_search.js",
     "test:unit": "node --test tests/*.test.js",
     "test:editor-local-access": "node tests/map-editor-local-access.test.js",
     "test:editor-server": "node tests/editor-server.test.js",

--- a/scripts/benchmark_secondary_search.js
+++ b/scripts/benchmark_secondary_search.js
@@ -1,0 +1,111 @@
+const fs = require('node:fs');
+const { performance } = require('node:perf_hooks');
+
+const appSourcePath = process.env.SEARCH_BENCH_APP_SOURCE || 'js/app.js';
+const appSource = fs.readFileSync(appSourcePath, 'utf8');
+
+function extractFunctionSource(name, { optional = false } = {}) {
+    const start = appSource.indexOf(`function ${name}(`);
+    if (start === -1) {
+        if (optional) return '';
+        throw new Error(`Could not find function ${name}`);
+    }
+    let depth = 0;
+    let end = -1;
+    for (let i = start; i < appSource.length; i += 1) {
+        const char = appSource[i];
+        if (char === '{') depth += 1;
+        if (char === '}') {
+            depth -= 1;
+            if (depth === 0) {
+                end = i + 1;
+                break;
+            }
+        }
+    }
+    if (end === -1) {
+        throw new Error(`Could not parse function ${name}`);
+    }
+    return appSource.slice(start, end);
+}
+
+const snippets = [
+    extractFunctionSource('getSecondarySearchMatchCache', { optional: true }),
+    extractFunctionSource('rememberSecondarySearchMatch', { optional: true }),
+    extractFunctionSource('getFuzzyMatchScore'),
+    extractFunctionSource('checkPrimarySearchMatch'),
+    extractFunctionSource('checkSecondarySearchMatch'),
+    extractFunctionSource('computePrecomputedSearchMatch')
+].filter(Boolean).join('\n');
+
+// eslint-disable-next-line no-eval
+eval(snippets);
+
+const itemCount = Number(process.env.SEARCH_BENCH_ITEMS || 8000);
+const rounds = Number(process.env.SEARCH_BENCH_ROUNDS || 8);
+const terms = [
+    'swcst',
+    'mnrte',
+    'hdaqe',
+    'crwnrd',
+    'qzzqx',
+    'vltsp',
+    'rbmkt',
+    'wntrgt'
+];
+
+const secondaryTemplate = [
+    'silver watch coast road causeway',
+    'winter gate marker route under moonrise',
+    'hidden archive quarter eastward',
+    'ribbon market district with old canal stones',
+    'vault spiral passage below the crown ridge',
+    'amber lantern ferry crossing and river dock',
+    'overgrown sentinel tower with civic records',
+    'storm chapel overlook beside blackwater marsh'
+].join(' ');
+
+function buildEntries() {
+    return Array.from({ length: itemCount }, (_, index) => ({
+        primary: `marker ${index}`,
+        secondary: `${secondaryTemplate} ${index} ${secondaryTemplate}`,
+        context: {}
+    }));
+}
+
+function runBenchmark(entries) {
+    let checksum = 0;
+    const startedAt = performance.now();
+    for (let round = 0; round < rounds; round += 1) {
+        for (const term of terms) {
+            for (const entry of entries) {
+                const match = computePrecomputedSearchMatch(term, entry.primary, entry.secondary, entry.context);
+                checksum += match.matched ? match.score : -1;
+            }
+        }
+    }
+    return {
+        checksum,
+        elapsedMs: performance.now() - startedAt
+    };
+}
+
+const coldResult = runBenchmark(buildEntries());
+const warmEntries = buildEntries();
+runBenchmark(warmEntries);
+const warmResult = runBenchmark(warmEntries);
+
+if (coldResult.checksum !== warmResult.checksum) {
+    throw new Error(`Benchmark checksums diverged: cold=${coldResult.checksum}, warm=${warmResult.checksum}`);
+}
+
+console.log(JSON.stringify({
+    appSourcePath,
+    itemCount,
+    rounds,
+    termCount: terms.length,
+    operations: itemCount * rounds * terms.length,
+    coldElapsedMs: Number(coldResult.elapsedMs.toFixed(2)),
+    warmElapsedMs: Number(warmResult.elapsedMs.toFixed(2)),
+    checksum: warmResult.checksum
+}, null, 2));

--- a/tests/checkSecondarySearchMatch.test.js
+++ b/tests/checkSecondarySearchMatch.test.js
@@ -28,6 +28,8 @@ function extractFunctionSource(name) {
 }
 
 const snippets = [
+    extractFunctionSource('getSecondarySearchMatchCache'),
+    extractFunctionSource('rememberSecondarySearchMatch'),
     extractFunctionSource('getFuzzyMatchScore'),
     extractFunctionSource('checkSecondarySearchMatch')
 ].join('\n');
@@ -53,5 +55,28 @@ assert.deepEqual(longFuzzyMatch, { matched: true, score: 80, matchedByContent: t
 // no match
 const noMatch = checkSecondarySearchMatch('zzz', 'a cold harbor city');
 assert.equal(noMatch, null);
+
+const cachedSearchContext = {};
+const cachedFuzzyMatch = checkSecondarySearchMatch('cdh', 'a cold harbor city', cachedSearchContext);
+assert.deepEqual(cachedFuzzyMatch, fuzzyMatch);
+assert.equal(cachedSearchContext._secondarySearchMatchText, 'a cold harbor city');
+assert.ok(cachedSearchContext._secondarySearchMatchCache);
+assert.equal(cachedSearchContext._secondarySearchMatchCache.get('cdh'), cachedFuzzyMatch);
+
+const cachedSearchResults = cachedSearchContext._secondarySearchMatchCache;
+checkSecondarySearchMatch('ach', 'a cold harbor city', cachedSearchContext);
+assert.equal(cachedSearchContext._secondarySearchMatchCache, cachedSearchResults);
+
+const exactSearchContext = {};
+const cachedExactMatch = checkSecondarySearchMatch('cold', 'a cold harbor city', exactSearchContext);
+assert.deepEqual(cachedExactMatch, exactMatch);
+assert.equal(exactSearchContext._secondarySearchMatchCache.get('cold'), cachedExactMatch);
+
+const boundedSearchContext = {};
+for (let i = 0; i < 40; i += 1) {
+    checkSecondarySearchMatch(`z${i}`, 'a cold harbor city', boundedSearchContext);
+}
+assert.equal(boundedSearchContext._secondarySearchMatchCache.size, 32);
+assert.equal(boundedSearchContext._secondarySearchMatchCache.has('z0'), false);
 
 console.log('checkSecondarySearchMatch tests passed');

--- a/tests/computeSearchMatch.test.js
+++ b/tests/computeSearchMatch.test.js
@@ -29,6 +29,8 @@ function extractFunctionSource(name) {
 
 const snippets = [
     extractFunctionSource('normalizeSearchValue'),
+    extractFunctionSource('getSecondarySearchMatchCache'),
+    extractFunctionSource('rememberSecondarySearchMatch'),
     extractFunctionSource('getFuzzyMatchScore'),
     extractFunctionSource('checkPrimarySearchMatch'),
     extractFunctionSource('checkSecondarySearchMatch'),
@@ -57,6 +59,7 @@ assert.equal(computeSearchMatch('zzz', 'Icebeach', '').matched, false);
 
 const precomputedPrimary = normalizeSearchValue('Icebeach');
 const precomputedSecondary = normalizeSearchValue('A cold harbor city');
+const precomputedSearchContext = {};
 
 assert.deepEqual(
     computePrecomputedSearchMatch('ice', precomputedPrimary, precomputedSecondary),
@@ -69,6 +72,16 @@ assert.deepEqual(
 assert.deepEqual(
     computePrecomputedSearchMatch('zzz', precomputedPrimary, precomputedSecondary),
     computeSearchMatch('zzz', 'Icebeach', 'A cold harbor city')
+);
+assert.deepEqual(
+    computePrecomputedSearchMatch('cdh', precomputedPrimary, precomputedSecondary, precomputedSearchContext),
+    computeSearchMatch('cdh', 'Icebeach', 'A cold harbor city')
+);
+assert.equal(precomputedSearchContext._secondarySearchMatchText, precomputedSecondary);
+assert.ok(precomputedSearchContext._secondarySearchMatchCache);
+assert.equal(
+    precomputedSearchContext._secondarySearchMatchCache.get('cdh').score,
+    computeSearchMatch('cdh', 'Icebeach', 'A cold harbor city').score
 );
 
 console.log('computeSearchMatch regression checks passed');


### PR DESCRIPTION
## 💡 What

Caches secondary search match results on the existing per-marker and atlas-entry search context objects, bounded to 32 query terms per secondary text. The secondary matcher now also runs fuzzy matching before exact substring confirmation so clear misses avoid paying both `includes()` and fuzzy traversal.

Added `npm run benchmark:secondary-search` to reproduce the focused benchmark against either the working tree or a supplied app source file.

## 🎯 Why

Secondary search content can be much larger than POI names and is searched repeatedly across markers and atlas entries. Before this change, repeated searches recomputed exact substring scans and fuzzy scores for the same normalized secondary strings and terms.

## 📊 Measured Improvement

Measured with `npm run benchmark:secondary-search` over 8,000 synthetic entries, 8 terms, 8 rounds, 512,000 operations per measurement.

Baseline from `origin/main` source:

```json
{
  "coldElapsedMs": 583.06,
  "warmElapsedMs": 573.2
}
```

Optimized working tree:

```json
{
  "coldElapsedMs": 220.27,
  "warmElapsedMs": 143.82
}
```

Cold run improved by 362.79 ms, about 62.2% faster. Warm cached run improved by 429.38 ms, about 74.9% faster.

## Validation

- `npm run benchmark:secondary-search`
- `env SEARCH_BENCH_APP_SOURCE=/private/tmp/map-hiraeth-app-baseline.js npm run benchmark:secondary-search`
- `git diff --check`
- `npm test`