### PR TITLE
🔒 Sentinel: [HIGH] Fix CSRF Vulnerability via Missing Origin/Referer in Editor Server

### DIFF
--- a/dist/maps/atlas-index.json
+++ b/dist/maps/atlas-index.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-06-24T20:42:41.707Z",
+  "generatedAt": "2026-06-24T21:20:13.250Z",
   "tree": [
     {
       "type": "folder",

--- a/maps/atlas-index.json
+++ b/maps/atlas-index.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-06-24T20:42:41.707Z",
+  "generatedAt": "2026-06-24T21:20:13.250Z",
   "tree": [
     {
       "type": "folder",

--- a/scripts/editor_server.js
+++ b/scripts/editor_server.js
@@ -90,7 +90,7 @@ function isAllowedEditorWriteRequest(request) {
     const referer = String(request.headers.referer || '').trim();
     if (referer) return isSameLocalEditorOrigin(referer, request.headers.host);
 
-    return true;
+    return false;
 }
 
 function resolveRepoPath(repoRoot, relativePath) {

--- a/tests/editor-server.test.js
+++ b/tests/editor-server.test.js
@@ -58,7 +58,7 @@ assert.equal(isAllowedEditorWriteRequest({
         origin: 'http://0.0.0.0:8010'
     }
 }), false);
-assert.equal(isAllowedEditorWriteRequest({ headers: { host: '127.0.0.1:8010' } }), true);
+assert.equal(isAllowedEditorWriteRequest({ headers: { host: '127.0.0.1:8010' } }), false);
 
 assert.equal(
     resolveMapTargetPath(repoRoot, { dataUrl: 'maps/IceBeach.json' }).relativePath,


### PR DESCRIPTION
🎯 **What:** The `isAllowedEditorWriteRequest` function returned `true` if both `Origin` and `Referer` headers were missing, allowing unverified requests to execute operations. This fix changes the default fallback to `return false;`.
⚠️ **Risk:** An attacker could execute Cross-Site Request Forgery (CSRF) attacks by forcing requests with 'no-referrer', potentially modifying or corrupting map and atlas documents on the user's local editor server.
🛡️ **Solution:** Changed the default fallback in `isAllowedEditorWriteRequest` from `return true` to `return false`, ensuring that requests must have a valid and matching `Origin` or `Referer` header to be processed. Test expectations were also updated to reflect this stricter requirement.

---
*PR created automatically by Jules for task [13742859428701751978](https://jules.google.com/task/13742859428701751978) started by @jaxsnjohnson*