### PR TITLE
⚡ Optimize fuzzy match scoring

### DIFF
--- a/dist/js/app.js
+++ b/dist/js/app.js
@@ -3165,17 +3165,29 @@ function getFuzzyMatchScore(term, target) {
     let lastMatchIndex = -1;
     let spreadPenalty = 0;
 
-    for (const char of term) {
+    for (let termIndex = 0; termIndex < term.length;) {
+        const firstCodeUnit = term.charCodeAt(termIndex);
+        let char = term[termIndex];
+        termIndex += 1;
+
+        if (firstCodeUnit >= 0xd800 && firstCodeUnit <= 0xdbff && termIndex < term.length) {
+            const secondCodeUnit = term.charCodeAt(termIndex);
+            if (secondCodeUnit >= 0xdc00 && secondCodeUnit <= 0xdfff) {
+                char += term[termIndex];
+                termIndex += 1;
+            }
+        }
+
         const foundIndex = target.indexOf(char, searchIndex);
         if (foundIndex === -1) return -1;
-        if (lastMatchIndex >= 0) {
-            spreadPenalty += Math.max(0, foundIndex - lastMatchIndex - 1);
+        if (lastMatchIndex >= 0 && spreadPenalty < 120) {
+            spreadPenalty += foundIndex - lastMatchIndex - 1;
         }
         lastMatchIndex = foundIndex;
         searchIndex = foundIndex + 1;
     }
 
-    return Math.max(40, 160 - spreadPenalty);
+    return spreadPenalty >= 120 ? 40 : 160 - spreadPenalty;
 }
 
 function checkPrimarySearchMatch(term, normalizedPrimary) {

--- a/js/app.js
+++ b/js/app.js
@@ -3165,17 +3165,29 @@ function getFuzzyMatchScore(term, target) {
     let lastMatchIndex = -1;
     let spreadPenalty = 0;
 
-    for (const char of term) {
+    for (let termIndex = 0; termIndex < term.length;) {
+        const firstCodeUnit = term.charCodeAt(termIndex);
+        let char = term[termIndex];
+        termIndex += 1;
+
+        if (firstCodeUnit >= 0xd800 && firstCodeUnit <= 0xdbff && termIndex < term.length) {
+            const secondCodeUnit = term.charCodeAt(termIndex);
+            if (secondCodeUnit >= 0xdc00 && secondCodeUnit <= 0xdfff) {
+                char += term[termIndex];
+                termIndex += 1;
+            }
+        }
+
         const foundIndex = target.indexOf(char, searchIndex);
         if (foundIndex === -1) return -1;
-        if (lastMatchIndex >= 0) {
-            spreadPenalty += Math.max(0, foundIndex - lastMatchIndex - 1);
+        if (lastMatchIndex >= 0 && spreadPenalty < 120) {
+            spreadPenalty += foundIndex - lastMatchIndex - 1;
         }
         lastMatchIndex = foundIndex;
         searchIndex = foundIndex + 1;
     }
 
-    return Math.max(40, 160 - spreadPenalty);
+    return spreadPenalty >= 120 ? 40 : 160 - spreadPenalty;
 }
 
 function checkPrimarySearchMatch(term, normalizedPrimary) {

--- a/scripts/benchmark_search_match.js
+++ b/scripts/benchmark_search_match.js
@@ -25,30 +25,29 @@ function extractFunctionSource(name) {
 }
 
 const snippets = [
-    extractFunctionSource('getFuzzyMatchScore'),
-    extractFunctionSource('checkPrimarySearchMatch')
+    extractFunctionSource('getFuzzyMatchScore')
 ].join('\n');
 
 // eslint-disable-next-line no-eval
 eval(snippets);
 
-function legacyCheckPrimarySearchMatch(term, normalizedPrimary) {
-    if (normalizedPrimary === term) {
-        return { matched: true, score: 520, matchedByContent: false };
-    }
-    if (normalizedPrimary.startsWith(term)) {
-        return { matched: true, score: 430, matchedByContent: false };
-    }
-    const primaryIndex = normalizedPrimary.indexOf(term);
-    if (primaryIndex >= 0) {
-        return { matched: true, score: 320 - Math.min(primaryIndex, 120), matchedByContent: false };
+function legacyGetFuzzyMatchScore(term, target) {
+    if (!term || !target) return -1;
+    let searchIndex = 0;
+    let lastMatchIndex = -1;
+    let spreadPenalty = 0;
+
+    for (const char of term) {
+        const foundIndex = target.indexOf(char, searchIndex);
+        if (foundIndex === -1) return -1;
+        if (lastMatchIndex >= 0) {
+            spreadPenalty += Math.max(0, foundIndex - lastMatchIndex - 1);
+        }
+        lastMatchIndex = foundIndex;
+        searchIndex = foundIndex + 1;
     }
 
-    const fuzzyScore = getFuzzyMatchScore(term, normalizedPrimary);
-    if (fuzzyScore >= 0) {
-        return { matched: true, score: fuzzyScore, matchedByContent: false };
-    }
-    return null;
+    return Math.max(40, 160 - spreadPenalty);
 }
 
 function buildCorpus() {
@@ -65,20 +64,19 @@ function buildCorpus() {
             corpus.push([term, `unrelated waypoint ${i}`]);
         }
     }
+    corpus.push(['😀a', '😀a']);
+    corpus.push(['a😀', 'a😀']);
+    corpus.push(['😀b', `😀${'x'.repeat(40)}b`]);
     return corpus;
 }
 
-function runBenchmark(label, matcher, corpus, iterations) {
+function runBenchmark(label, scorer, corpus, iterations) {
     const start = performance.now();
     let checksum = 0;
 
     for (let iteration = 0; iteration < iterations; iteration += 1) {
-        for (const [term, normalizedPrimary] of corpus) {
-            const match = matcher(term, normalizedPrimary);
-            if (match) {
-                checksum += match.score;
-                if (match.matchedByContent) checksum += 1;
-            }
+        for (const [term, target] of corpus) {
+            checksum += scorer(term, target);
         }
     }
 
@@ -105,18 +103,18 @@ const currentDurations = [];
 let legacyChecksum = 0;
 let currentChecksum = 0;
 
-runBenchmark('warmup legacy', legacyCheckPrimarySearchMatch, corpus, 5);
-runBenchmark('warmup current', checkPrimarySearchMatch, corpus, 5);
+runBenchmark('warmup legacy', legacyGetFuzzyMatchScore, corpus, 5);
+runBenchmark('warmup current', getFuzzyMatchScore, corpus, 5);
 
 for (let round = 0; round < rounds; round += 1) {
     const first = round % 2 === 0
         ? [
-            ['legacy', legacyCheckPrimarySearchMatch],
-            ['current', checkPrimarySearchMatch]
+            ['legacy', legacyGetFuzzyMatchScore],
+            ['current', getFuzzyMatchScore]
         ]
         : [
-            ['current', checkPrimarySearchMatch],
-            ['legacy', legacyCheckPrimarySearchMatch]
+            ['current', getFuzzyMatchScore],
+            ['legacy', legacyGetFuzzyMatchScore]
         ];
 
     for (const [label, matcher] of first) {
@@ -143,7 +141,7 @@ const percent = legacyMedian === 0 ? 0 : (delta / legacyMedian) * 100;
 console.log(`Corpus entries: ${corpus.length}`);
 console.log(`Iterations per round: ${iterations}`);
 console.log(`Rounds: ${rounds}`);
-console.log(`Legacy median: ${legacyMedian.toFixed(2)} ms`);
-console.log(`Current median: ${currentMedian.toFixed(2)} ms`);
+console.log(`Legacy fuzzy median: ${legacyMedian.toFixed(2)} ms`);
+console.log(`Current fuzzy median: ${currentMedian.toFixed(2)} ms`);
 console.log(`Delta: ${delta.toFixed(2)} ms (${percent.toFixed(2)}%)`);
 console.log(`Checksum: ${currentChecksum}`);

--- a/tests/getFuzzyMatchScore.test.js
+++ b/tests/getFuzzyMatchScore.test.js
@@ -68,6 +68,9 @@ assert.equal(getFuzzyMatchScore('ac', 'abc'), 159, 'Should penalize score based 
 // score = max(40, 160-2) = 158
 assert.equal(getFuzzyMatchScore('ace', 'abcde'), 158, 'Should accumulate spread penalties');
 
+assert.equal(getFuzzyMatchScore('😀a', '😀a'), 159, 'Should preserve spread scoring for leading astral symbols');
+assert.equal(getFuzzyMatchScore('a😀', 'a😀'), 160, 'Should preserve adjacent astral symbol matches');
+
 // Max spread penalty behaviors (minimum score is 40)
 // spread penalty >= 120 should hit the floor of 40
 // let's construct a string with spread 150


### PR DESCRIPTION
## 💡 What

Optimizes `getFuzzyMatchScore` by replacing the iterator-based character loop with an index-based code-point loop, removing redundant `Math.max` work, and short-circuiting spread-penalty accumulation once the score floor is reached. The shipped `dist/js/app.js` bundle is synced with the source change.

Also repoints `npm run benchmark:search` at the fuzzy scorer itself so future runs compare the embedded legacy scorer against the current implementation.

## 🎯 Why

`getFuzzyMatchScore` runs across many normalized search text segments. The previous implementation allocated/iterated through `for...of` and recalculated a defensive max on every matched character, even though each subsequent match position is guaranteed to move forward.

## 📊 Measured Improvement

Direct fuzzy-score benchmark from `npm run benchmark:search`:

- Corpus entries: 28,803
- Iterations per round: 80
- Rounds: 9
- Legacy fuzzy median: 1107.73 ms
- Current fuzzy median: 159.85 ms
- Delta: 947.88 ms faster, 85.57% improvement
- Checksum: 305699040

A pre-change run of the previous broader search benchmark was also captured before editing: current median 409.77 ms on its older primary-match harness. The updated benchmark is more directly tied to this PR's optimized helper.

## ✅ Validation

- `node --check js/app.js`
- `node --check scripts/benchmark_search_match.js`
- `node --test tests/getFuzzyMatchScore.test.js`
- `npm run benchmark:search`
- `npm run validate:pages`
- `git diff --check`

No package lint or format scripts are defined, so syntax and whitespace checks were used for those gates.